### PR TITLE
feat: add second option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Go version 1.23+.
 | day                    |    ✅︎    |
 | hour                   |    ✅︎    |
 | minute                 |    ✅︎    |
-| second                 |    ❌     |
+| second                 |    ✅︎    |
 | fractionalSecondDigits |    ❌     |
 | weekday                |    ❌     |
 | hourCycle              |    ❌     |

--- a/fmt_hms.go
+++ b/fmt_hms.go
@@ -1,0 +1,18 @@
+package intl
+
+import (
+	"go.expect.digital/intl/internal/symbols"
+	"golang.org/x/text/language"
+)
+
+func seqHourMinuteSecond(locale language.Tag, opts Options) *symbols.Seq {
+	return symbols.NewSeq(locale).Add(opts.Hour.symbol(), symbols.TxtColon, opts.Minute.symbol(), symbols.TxtColon, opts.Second.symbol())
+}
+
+func seqHourMinuteSecondPersian(locale language.Tag, opts Options) *symbols.Seq {
+	return symbols.NewSeq(locale).Add(opts.Hour.symbol(), symbols.TxtColon, opts.Minute.symbol(), symbols.TxtColon, opts.Second.symbol())
+}
+
+func seqHourMinuteSecondBuddhist(locale language.Tag, opts Options) *symbols.Seq {
+	return symbols.NewSeq(locale).Add(opts.Hour.symbol(), symbols.TxtColon, opts.Minute.symbol(), symbols.TxtColon, opts.Second.symbol())
+}

--- a/fmt_ms.go
+++ b/fmt_ms.go
@@ -1,0 +1,18 @@
+package intl
+
+import (
+	"go.expect.digital/intl/internal/symbols"
+	"golang.org/x/text/language"
+)
+
+func seqMinuteSecond(locale language.Tag, opts Options) *symbols.Seq {
+	return symbols.NewSeq(locale).Add(opts.Minute.symbol(), symbols.TxtColon, opts.Second.symbol())
+}
+
+func seqMinuteSecondPersian(locale language.Tag, opts Options) *symbols.Seq {
+	return symbols.NewSeq(locale).Add(opts.Minute.symbol(), symbols.TxtColon, opts.Second.symbol())
+}
+
+func seqMinuteSecondBuddhist(locale language.Tag, opts Options) *symbols.Seq {
+	return symbols.NewSeq(locale).Add(opts.Minute.symbol(), symbols.TxtColon, opts.Second.symbol())
+}

--- a/fmt_s.go
+++ b/fmt_s.go
@@ -1,0 +1,18 @@
+package intl
+
+import (
+	"go.expect.digital/intl/internal/symbols"
+	"golang.org/x/text/language"
+)
+
+func seqSecond(locale language.Tag, opt Second) *symbols.Seq {
+	return symbols.NewSeq(locale).Add(opt.symbol())
+}
+
+func seqSecondPersian(locale language.Tag, opt Second) *symbols.Seq {
+	return symbols.NewSeq(locale).Add(opt.symbol())
+}
+
+func seqSecondBuddhist(locale language.Tag, opt Second) *symbols.Seq {
+	return symbols.NewSeq(locale).Add(opt.symbol())
+}

--- a/internal/cldr/fmt.go
+++ b/internal/cldr/fmt.go
@@ -11,6 +11,7 @@ type TimeReader interface {
 	Day() int
 	Hour() int
 	Minute() int
+	Second() int
 }
 
 type Fmt []FmtFunc
@@ -99,4 +100,16 @@ type MinuteTwoDigit Digits
 
 func (m MinuteTwoDigit) Format(b *strings.Builder, t TimeReader) {
 	Digits(m).appendTwoDigit(b, t.Minute())
+}
+
+type SecondNumeric Digits
+
+func (s SecondNumeric) Format(b *strings.Builder, t TimeReader) {
+	Digits(s).appendNumeric(b, t.Second())
+}
+
+type SecondTwoDigit Digits
+
+func (s SecondTwoDigit) Format(b *strings.Builder, t TimeReader) {
+	Digits(s).appendTwoDigit(b, t.Second())
 }

--- a/internal/symbols/symbols.go
+++ b/internal/symbols/symbols.go
@@ -66,6 +66,8 @@ const (
 	Symbol_HH    // HH, two-digit hour
 	Symbol_m     // m, minute
 	Symbol_mm    // mm, two-digit minute
+	Symbol_s     // s, second
+	Symbol_ss    // ss, two-digit second
 )
 
 func (s Symbol) String() string {
@@ -197,6 +199,10 @@ func (s *Seq) Func() func(cldr.TimeReader) string {
 			symFmt = cldr.MinuteNumeric(digits)
 		case Symbol_mm:
 			symFmt = cldr.MinuteTwoDigit(digits)
+		case Symbol_s:
+			symFmt = cldr.SecondNumeric(digits)
+		case Symbol_ss:
+			symFmt = cldr.SecondTwoDigit(digits)
 		case MonthUnit:
 			symFmt = cldr.Text(cldr.UnitName(s.locale).Month)
 		case DayUnit:

--- a/intl_test.go
+++ b/intl_test.go
@@ -71,6 +71,15 @@ func (t *Test) String() string {
 		sb.WriteString(t.Options.Minute.String())
 	}
 
+	if !t.Options.Second.und() {
+		if sb.Len() > 0 {
+			sb.WriteRune(',')
+		}
+
+		sb.WriteString("second=")
+		sb.WriteString(t.Options.Second.String())
+	}
+
 	if sb.Len() > 0 {
 		sb.WriteRune(',')
 	}
@@ -135,6 +144,10 @@ func (t *Test) UnmarshalJSON(b []byte) error {
 
 		if v, ok := o["minute"].(string); ok {
 			test.Options.Minute = MustParseMinute(v)
+		}
+
+		if v, ok := o["second"].(string); ok {
+			test.Options.Second = MustParseSecond(v)
 		}
 	}
 

--- a/second_test.go
+++ b/second_test.go
@@ -1,0 +1,90 @@
+package intl
+
+import (
+	"testing"
+	"time"
+
+	"golang.org/x/text/language"
+)
+
+func TestDateTimeFormat_Second(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		locale  string
+		options Options
+		want    string
+	}{
+		{"lv", Options{Second: Second2Digit}, "05"},
+		{"fa", Options{Second: SecondNumeric}, "۵"},
+		{"fa", Options{Second: Second2Digit}, "۰۵"},
+	}
+
+	date := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.locale+"_"+tt.options.Second.String(), func(t *testing.T) {
+			t.Parallel()
+
+			got := NewDateTimeFormat(language.Make(tt.locale), tt.options).Format(date)
+			if got != tt.want {
+				t.Fatalf("want %q got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestDateTimeFormat_MinuteSecond(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		locale  string
+		options Options
+		want    string
+	}{
+		{"lv", Options{Minute: Minute2Digit, Second: Second2Digit}, "04:05"},
+		{"fa", Options{Minute: MinuteNumeric, Second: SecondNumeric}, "۴:۵"},
+	}
+
+	date := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.locale, func(t *testing.T) {
+			t.Parallel()
+
+			got := NewDateTimeFormat(language.Make(tt.locale), tt.options).Format(date)
+			if got != tt.want {
+				t.Fatalf("want %q got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestDateTimeFormat_HourMinuteSecond(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		locale  string
+		options Options
+		want    string
+	}{
+		{"lv", Options{Hour: Hour2Digit, Minute: Minute2Digit, Second: Second2Digit}, "03:04:05"},
+		{"fa", Options{Hour: HourNumeric, Minute: MinuteNumeric, Second: SecondNumeric}, "۳:۴:۵"},
+	}
+
+	date := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.locale, func(t *testing.T) {
+			t.Parallel()
+
+			got := NewDateTimeFormat(language.Make(tt.locale), tt.options).Format(date)
+			if got != tt.want {
+				t.Fatalf("want %q got %q", tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add `Second` option and parser
- format seconds and combinations with minutes and hours
- update documentation and tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689368fd71b8832f9acebdd0cbe42644