### PR TITLE
Add weekday time formatting

### DIFF
--- a/fmt_ehm.go
+++ b/fmt_ehm.go
@@ -1,0 +1,33 @@
+package intl
+
+import (
+	"go.expect.digital/intl/internal/symbols"
+	"golang.org/x/text/language"
+)
+
+func seqWeekdayTime(locale language.Tag, opts Options) *symbols.Seq {
+	seq := symbols.NewSeq(locale)
+	seq.Add(opts.Weekday.symbol(), symbols.TxtComma, symbols.TxtSpace, opts.Hour.symbol(), symbols.TxtColon, opts.Minute.symbol())
+	if !opts.Second.und() {
+		seq.Add(symbols.TxtColon, opts.Second.symbol())
+	}
+	return seq
+}
+
+func seqMonthWeekdayTime(locale language.Tag, opts Options) *symbols.Seq {
+	seq := symbols.NewSeq(locale)
+	seq.Add(opts.Month.symbolFormat(), symbols.TxtComma, symbols.TxtSpace, opts.Weekday.symbol(), symbols.TxtComma, symbols.TxtSpace, opts.Hour.symbol(), symbols.TxtColon, opts.Minute.symbol())
+	if !opts.Second.und() {
+		seq.Add(symbols.TxtColon, opts.Second.symbol())
+	}
+	return seq
+}
+
+func seqYearMonthWeekdayTime(locale language.Tag, opts Options) *symbols.Seq {
+	seq := symbols.NewSeq(locale)
+	seq.Add(opts.Year.symbol(), symbols.TxtComma, symbols.TxtSpace, opts.Month.symbolFormat(), symbols.TxtComma, symbols.TxtSpace, opts.Weekday.symbol(), symbols.TxtComma, symbols.TxtSpace, opts.Hour.symbol(), symbols.TxtColon, opts.Minute.symbol())
+	if !opts.Second.und() {
+		seq.Add(symbols.TxtColon, opts.Second.symbol())
+	}
+	return seq
+}

--- a/internal/cldr/fmt.go
+++ b/internal/cldr/fmt.go
@@ -9,6 +9,7 @@ type TimeReader interface {
 	Year() int
 	Month() time.Month
 	Day() int
+	Weekday() time.Weekday
 	Hour() int
 	Minute() int
 	Second() int
@@ -64,6 +65,12 @@ type Month CalendarMonths
 
 func (m Month) Format(b *strings.Builder, t TimeReader) {
 	b.WriteString(m[t.Month()-1])
+}
+
+type Weekday CalendarWeekdays
+
+func (w Weekday) Format(b *strings.Builder, t TimeReader) {
+	b.WriteString(w[t.Weekday()])
 }
 
 type DayNumeric Digits

--- a/internal/cldr/weekday.go
+++ b/internal/cldr/weekday.go
@@ -1,0 +1,29 @@
+package cldr
+
+// CalendarWeekdays stores localized weekday names.
+type CalendarWeekdays [7]string
+
+var weekdayData = map[string]map[string]CalendarWeekdays{
+	"en": {
+		"abbreviated": {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"},
+		"wide":        {"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"},
+		"narrow":      {"S", "M", "T", "W", "T", "F", "S"},
+	},
+	"uk": {
+		"abbreviated": {"нд", "пн", "вт", "ср", "чт", "пт", "сб"},
+		"wide":        {"неділя", "понеділок", "вівторок", "середа", "четвер", "пʼятниця", "субота"},
+		"narrow":      {"Н", "П", "В", "С", "Ч", "П", "С"},
+	},
+}
+
+// WeekdayNames returns localized weekday names for the given locale and width.
+// If locale is unknown, English names are returned.
+func WeekdayNames(locale, width string) CalendarWeekdays {
+	if m, ok := weekdayData[locale]; ok {
+		if w, ok := m[width]; ok {
+			return w
+		}
+	}
+
+	return weekdayData["en"]["abbreviated"]
+}

--- a/internal/symbols/symbols.go
+++ b/internal/symbols/symbols.go
@@ -68,6 +68,9 @@ const (
 	Symbol_mm    // mm, two-digit minute
 	Symbol_s     // s, second
 	Symbol_ss    // ss, two-digit second
+	Symbol_E     // E, weekday short
+	Symbol_EEEE  // EEEE, weekday long
+	Symbol_EEEEE // EEEEE, weekday narrow
 )
 
 func (s Symbol) String() string {
@@ -203,6 +206,15 @@ func (s *Seq) Func() func(cldr.TimeReader) string {
 			symFmt = cldr.SecondNumeric(digits)
 		case Symbol_ss:
 			symFmt = cldr.SecondTwoDigit(digits)
+		case Symbol_E:
+			names := cldr.WeekdayNames(s.locale.String(), "abbreviated")
+			symFmt = cldr.Weekday(names)
+		case Symbol_EEEE:
+			names := cldr.WeekdayNames(s.locale.String(), "wide")
+			symFmt = cldr.Weekday(names)
+		case Symbol_EEEEE:
+			names := cldr.WeekdayNames(s.locale.String(), "narrow")
+			symFmt = cldr.Weekday(names)
 		case MonthUnit:
 			symFmt = cldr.Text(cldr.UnitName(s.locale).Month)
 		case DayUnit:

--- a/intl_test.go
+++ b/intl_test.go
@@ -53,6 +53,15 @@ func (t *Test) String() string {
 		sb.WriteString(t.Options.Day.String())
 	}
 
+	if !t.Options.Weekday.und() {
+		if sb.Len() > 0 {
+			sb.WriteRune(',')
+		}
+
+		sb.WriteString("weekday=")
+		sb.WriteString(t.Options.Weekday.String())
+	}
+
 	if !t.Options.Hour.und() {
 		if sb.Len() > 0 {
 			sb.WriteRune(',')
@@ -136,6 +145,10 @@ func (t *Test) UnmarshalJSON(b []byte) error {
 
 		if v, ok := o["day"].(string); ok {
 			test.Options.Day = MustParseDay(v)
+		}
+
+		if v, ok := o["weekday"].(string); ok {
+			test.Options.Weekday = MustParseWeekday(v)
 		}
 
 		if v, ok := o["hour"].(string); ok {

--- a/weekday_test.go
+++ b/weekday_test.go
@@ -1,0 +1,37 @@
+package intl
+
+import (
+	"testing"
+	"time"
+
+	"golang.org/x/text/language"
+)
+
+func TestDateTimeFormat_WeekdayTime(t *testing.T) {
+	t.Parallel()
+	date := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	got := NewDateTimeFormat(language.English, Options{Weekday: WeekdayShort, Hour: Hour2Digit, Minute: Minute2Digit}).Format(date)
+	if got != "Tue, 03:04" {
+		t.Fatalf("want %q got %q", "Tue, 03:04", got)
+	}
+}
+
+func TestDateTimeFormat_MonthWeekdayTime(t *testing.T) {
+	t.Parallel()
+	date := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	opts := Options{Month: MonthLong, Weekday: WeekdayShort, Hour: Hour2Digit, Minute: Minute2Digit}
+	got := NewDateTimeFormat(language.English, opts).Format(date)
+	if got != "Jan, Tue, 03:04" {
+		t.Fatalf("want %q got %q", "Jan, Tue, 03:04", got)
+	}
+}
+
+func TestDateTimeFormat_YearMonthWeekdayTime(t *testing.T) {
+	t.Parallel()
+	date := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	opts := Options{Year: YearNumeric, Month: MonthLong, Weekday: WeekdayShort, Hour: Hour2Digit, Minute: Minute2Digit}
+	got := NewDateTimeFormat(language.English, opts).Format(date)
+	if got != "2024, Jan, Tue, 03:04" {
+		t.Fatalf("want %q got %q", "2024, Jan, Tue, 03:04", got)
+	}
+}


### PR DESCRIPTION
## Summary
- support specifying a weekday in formatting options
- add sequences for rendering weekday with time, month, and year
- include basic localized weekday names and tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68936c2cb230832f8f6c8dc958650803