### PR TITLE
Add Month pattern variants

### DIFF
--- a/fmt_md.go
+++ b/fmt_md.go
@@ -19,7 +19,11 @@ func seqMonthDay(locale language.Tag, opts Options) *symbols.Seq {
 	case cldr.EN:
 		switch region {
 		default:
-			return seq.Add(month, '/', day)
+			if opts.Month.numeric() || opts.Month.twoDigit() {
+				return seq.Add(month, '/', day)
+			}
+
+			return seq.Add(month, symbols.TxtSpace, day)
 		case cldr.Region001, cldr.Region150, cldr.RegionAE, cldr.RegionAG, cldr.RegionAI, cldr.RegionAT, cldr.RegionBB,
 			cldr.RegionBM, cldr.RegionBS, cldr.RegionBW, cldr.RegionBZ, cldr.RegionCC, cldr.RegionCK, cldr.RegionCM,
 			cldr.RegionCX, cldr.RegionCY, cldr.RegionDE, cldr.RegionDG, cldr.RegionDK, cldr.RegionDM, cldr.RegionER,
@@ -41,21 +45,25 @@ func seqMonthDay(locale language.Tag, opts Options) *symbols.Seq {
 				return seq.Add(symbols.Symbol_dd, '/', symbols.Symbol_MM)
 			}
 
-			return seq.Add(day, '/', month)
+			return seq.Add(day, symbols.TxtSpace, month)
 		case cldr.RegionAU, cldr.RegionBE, cldr.RegionIE, cldr.RegionNZ, cldr.RegionZW:
-			return seq.Add(day, '/', month)
+			if opts.Month.numeric() || opts.Month.twoDigit() {
+				return seq.Add(day, '/', month)
+			}
+
+			return seq.Add(day, symbols.TxtSpace, month)
 		case cldr.RegionCA:
 			if opts.Month.numeric() && opts.Day.numeric() {
 				return seq.Add(symbols.Symbol_MM, '-', symbols.Symbol_dd)
 			}
 
-			return seq.Add(month, '-', day)
+			return seq.Add(month, symbols.TxtSpace, day)
 		case cldr.RegionCH:
 			if opts.Month.numeric() && opts.Day.numeric() {
 				return seq.Add(symbols.Symbol_dd, '.', symbols.Symbol_MM)
 			}
 
-			return seq.Add(day, '.', month)
+			return seq.Add(day, symbols.TxtSpace, month)
 		case cldr.RegionZA:
 			// month=numeric,day=numeric,out=01/02
 			// month=numeric,day=2-digit,out=01/02
@@ -65,7 +73,11 @@ func seqMonthDay(locale language.Tag, opts Options) *symbols.Seq {
 				return seq.Add(symbols.Symbol_dd, '/', symbols.Symbol_MM)
 			}
 
-			return seq.Add(symbols.Symbol_MM, '/', symbols.Symbol_dd)
+			if opts.Month.numeric() || opts.Month.twoDigit() {
+				return seq.Add(symbols.Symbol_MM, '/', symbols.Symbol_dd)
+			}
+
+			return seq.Add(symbols.Symbol_MM, symbols.TxtSpace, symbols.Symbol_dd)
 		}
 	case cldr.AF, cldr.AS, cldr.IA, cldr.KY, cldr.MI, cldr.RM, cldr.TG, cldr.WO:
 		return seq.Add(symbols.Symbol_dd, '-', symbols.Symbol_MM)

--- a/fmt_med.go
+++ b/fmt_med.go
@@ -1,0 +1,27 @@
+package intl
+
+import (
+	"go.expect.digital/intl/internal/symbols"
+	"golang.org/x/text/language"
+)
+
+func seqWeekdayMonthDay(locale language.Tag, opts Options) *symbols.Seq {
+	seq := symbols.NewSeq(locale)
+	seq.Add(opts.Weekday.symbol(), symbols.TxtComma, symbols.TxtSpace)
+	seq.AddSeq(seqMonthDay(locale, opts))
+	return seq
+}
+
+func seqWeekdayMonthDayPersian(locale language.Tag, opts Options) *symbols.Seq {
+	seq := symbols.NewSeq(locale)
+	seq.Add(opts.Weekday.symbol(), symbols.TxtComma, symbols.TxtSpace)
+	seq.AddSeq(seqMonthDayPersian(locale, opts))
+	return seq
+}
+
+func seqWeekdayMonthDayBuddhist(locale language.Tag, opts Options) *symbols.Seq {
+	seq := symbols.NewSeq(locale)
+	seq.Add(opts.Weekday.symbol(), symbols.TxtComma, symbols.TxtSpace)
+	seq.AddSeq(seqMonthDayBuddhist(locale, opts))
+	return seq
+}

--- a/fmt_ymd.go
+++ b/fmt_ymd.go
@@ -166,7 +166,11 @@ func seqYearMonthDay(locale language.Tag, opts Options) *symbols.Seq {
 	case cldr.EN:
 		switch region {
 		default:
-			return seq.Add(month, '/', day, '/', year)
+			if opts.Month.numeric() || opts.Month.twoDigit() {
+				return seq.Add(month, '/', day, '/', year)
+			}
+
+			return seq.Add(month, symbols.TxtSpace, day, symbols.TxtComma, symbols.TxtSpace, year)
 		case cldr.Region001, cldr.Region150, cldr.RegionAE, cldr.RegionAG, cldr.RegionAI, cldr.RegionAT, cldr.RegionBB,
 			cldr.RegionBM, cldr.RegionBS, cldr.RegionCC, cldr.RegionCK, cldr.RegionCM, cldr.RegionCX, cldr.RegionCY,
 			cldr.RegionDE, cldr.RegionDG, cldr.RegionDK, cldr.RegionDM, cldr.RegionER, cldr.RegionFI, cldr.RegionFJ,
@@ -195,7 +199,7 @@ func seqYearMonthDay(locale language.Tag, opts Options) *symbols.Seq {
 				return seq.Add(symbols.Symbol_dd, '/', symbols.Symbol_MM, '/', year)
 			}
 
-			return seq.Add(day, '/', month, '/', year)
+			return seq.Add(day, symbols.TxtSpace, month, symbols.TxtSpace, year)
 		case cldr.RegionAU, cldr.RegionSG:
 			// year=numeric,month=numeric,day=numeric,out=02/01/2024
 			// year=numeric,month=numeric,day=2-digit,out=02/01/2024

--- a/internal/symbols/symbols.go
+++ b/internal/symbols/symbols.go
@@ -59,8 +59,10 @@ const (
 	Symbol_d     // d, day
 	Symbol_dd    // dd, two-digit day
 	Symbol_LLL   // LLL, stand-alone abbreviated
+	Symbol_LLLL  // LLLL, stand-alone wide
 	Symbol_LLLLL // LLLLL, stand-alone narrow
 	Symbol_MMM   // MMM, format abbreviated
+	Symbol_MMMM  // MMMM, format wide
 	Symbol_MMMMM // MMMMM, format narrow
 	Symbol_H     // H, hour
 	Symbol_HH    // HH, two-digit hour
@@ -184,8 +186,14 @@ func (s *Seq) Func() func(cldr.TimeReader) string {
 		case Symbol_MMM:
 			names := cldr.MonthNames(s.locale.String(), "format", "abbreviated")
 			symFmt = cldr.Month(names)
+		case Symbol_MMMM:
+			names := cldr.MonthNames(s.locale.String(), "format", "wide")
+			symFmt = cldr.Month(names)
 		case Symbol_LLLLL:
 			names := cldr.MonthNames(s.locale.String(), "stand-alone", "narrow")
+			symFmt = cldr.Month(names)
+		case Symbol_LLLL:
+			names := cldr.MonthNames(s.locale.String(), "stand-alone", "wide")
 			symFmt = cldr.Month(names)
 		case Symbol_LLL:
 			names := cldr.MonthNames(s.locale.String(), "stand-alone", "abbreviated")

--- a/intl.go
+++ b/intl.go
@@ -255,12 +255,18 @@ func (m Month) symbol(context string) symbols.Symbol {
 		}
 
 		return symbols.Symbol_LLLLL
-	case MonthLong:
+	case MonthShort:
 		if context == "format" {
 			return symbols.Symbol_MMM
 		}
 
 		return symbols.Symbol_LLL
+	case MonthLong:
+		if context == "format" {
+			return symbols.Symbol_MMMM
+		}
+
+		return symbols.Symbol_LLLL
 	}
 }
 
@@ -740,6 +746,8 @@ func gregorianDateTimeFormat(locale language.Tag, opts Options) fmtFunc {
 		seq = seqYear(locale, opts.Year)
 	case !opts.Month.und() && !opts.Weekday.und() && !opts.Hour.und() && !opts.Minute.und():
 		seq = seqMonthWeekdayTime(locale, opts)
+	case !opts.Month.und() && !opts.Day.und() && !opts.Weekday.und():
+		seq = seqWeekdayMonthDay(locale, opts)
 	case !opts.Month.und() && !opts.Day.und():
 		seq = seqMonthDay(locale, opts)
 	case !opts.Month.und():
@@ -800,6 +808,8 @@ func persianDateTimeFormat(locale language.Tag, opts Options) fmtFunc {
 		seq = seqYearPersian(locale, opts.Year)
 	case !opts.Month.und() && !opts.Weekday.und() && !opts.Hour.und() && !opts.Minute.und():
 		seq = seqMonthWeekdayTime(locale, opts)
+	case !opts.Month.und() && !opts.Day.und() && !opts.Weekday.und():
+		seq = seqWeekdayMonthDayPersian(locale, opts)
 	case !opts.Month.und() && !opts.Day.und():
 		seq = seqMonthDayPersian(locale, opts)
 	case !opts.Month.und():
@@ -865,6 +875,8 @@ func buddhistDateTimeFormat(locale language.Tag, opts Options) fmtFunc {
 		seq = seqYearBuddhist(locale, opts)
 	case !opts.Month.und() && !opts.Weekday.und() && !opts.Hour.und() && !opts.Minute.und():
 		seq = seqMonthWeekdayTime(locale, opts)
+	case !opts.Month.und() && !opts.Day.und() && !opts.Weekday.und():
+		seq = seqWeekdayMonthDayBuddhist(locale, opts)
 	case !opts.Month.und() && !opts.Day.und():
 		seq = seqMonthDayBuddhist(locale, opts)
 	case !opts.Month.und():

--- a/layout_test.go
+++ b/layout_test.go
@@ -24,7 +24,7 @@ func TestDateTimeFormat_Layout_yMMMMEEEEd(t *testing.T) {
 	date := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
 	got := NewDateTimeFormatLayout(language.English, "yMMMMEEEEd").Format(date)
 
-	want := "Tuesday, Jan/2/2024"
+	want := "Tuesday, January 2, 2024"
 	if got != want {
 		t.Fatalf("want %q got %q", want, got)
 	}

--- a/month_test.go
+++ b/month_test.go
@@ -1,0 +1,77 @@
+package intl
+
+import (
+	"golang.org/x/text/language"
+	"testing"
+	"time"
+)
+
+func TestDateTimeFormat_Month(t *testing.T) {
+	t.Parallel()
+	date := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	tests := []struct {
+		options Options
+		want    string
+	}{
+		{Options{Month: MonthNumeric}, "1"},
+		{Options{Month: MonthShort}, "Jan"},
+		{Options{Month: MonthLong}, "January"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.options.Month.String(), func(t *testing.T) {
+			t.Parallel()
+			got := NewDateTimeFormat(language.English, tt.options).Format(date)
+			if got != tt.want {
+				t.Fatalf("want %q got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestDateTimeFormat_MonthDay(t *testing.T) {
+	t.Parallel()
+	date := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	tests := []struct {
+		options Options
+		want    string
+	}{
+		{Options{Month: MonthNumeric, Day: DayNumeric}, "1/2"},
+		{Options{Month: MonthShort, Day: DayNumeric}, "Jan 2"},
+		{Options{Month: MonthLong, Day: DayNumeric}, "January 2"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.options.Month.String(), func(t *testing.T) {
+			t.Parallel()
+			got := NewDateTimeFormat(language.English, tt.options).Format(date)
+			if got != tt.want {
+				t.Fatalf("want %q got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestDateTimeFormat_WeekdayMonthDay(t *testing.T) {
+	t.Parallel()
+	date := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	tests := []struct {
+		options Options
+		want    string
+	}{
+		{Options{Weekday: WeekdayShort, Month: MonthNumeric, Day: DayNumeric}, "Tue, 1/2"},
+		{Options{Weekday: WeekdayShort, Month: MonthShort, Day: DayNumeric}, "Tue, Jan 2"},
+		{Options{Weekday: WeekdayLong, Month: MonthLong, Day: DayNumeric}, "Tuesday, January 2"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		name := tt.options.Weekday.String() + "_" + tt.options.Month.String()
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := NewDateTimeFormat(language.English, tt.options).Format(date)
+			if got != tt.want {
+				t.Fatalf("want %q got %q", tt.want, got)
+			}
+		})
+	}
+}

--- a/weekday_test.go
+++ b/weekday_test.go
@@ -19,7 +19,7 @@ func TestDateTimeFormat_WeekdayTime(t *testing.T) {
 func TestDateTimeFormat_MonthWeekdayTime(t *testing.T) {
 	t.Parallel()
 	date := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
-	opts := Options{Month: MonthLong, Weekday: WeekdayShort, Hour: Hour2Digit, Minute: Minute2Digit}
+	opts := Options{Month: MonthShort, Weekday: WeekdayShort, Hour: Hour2Digit, Minute: Minute2Digit}
 	got := NewDateTimeFormat(language.English, opts).Format(date)
 	if got != "Jan, Tue, 03:04" {
 		t.Fatalf("want %q got %q", "Jan, Tue, 03:04", got)
@@ -29,7 +29,7 @@ func TestDateTimeFormat_MonthWeekdayTime(t *testing.T) {
 func TestDateTimeFormat_YearMonthWeekdayTime(t *testing.T) {
 	t.Parallel()
 	date := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
-	opts := Options{Year: YearNumeric, Month: MonthLong, Weekday: WeekdayShort, Hour: Hour2Digit, Minute: Minute2Digit}
+	opts := Options{Year: YearNumeric, Month: MonthShort, Weekday: WeekdayShort, Hour: Hour2Digit, Minute: Minute2Digit}
 	got := NewDateTimeFormat(language.English, opts).Format(date)
 	if got != "2024, Jan, Tue, 03:04" {
 		t.Fatalf("want %q got %q", "2024, Jan, Tue, 03:04", got)


### PR DESCRIPTION
## Summary
- add long and short month symbol definitions
- implement weekday-month-day sequence and selection logic
- handle month name spacing for month/day and year/month/day patterns
- cover month and weekday-month-day formatting with tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689462c970c8832fad947b6ff92c23de