### PR TITLE
Add quarter patterns and layout tests

### DIFF
--- a/fmt_yq.go
+++ b/fmt_yq.go
@@ -1,0 +1,19 @@
+package intl
+
+import (
+	"go.expect.digital/intl/internal/symbols"
+	"golang.org/x/text/language"
+)
+
+// seqYearQuarter formats a year and quarter, e.g. "Q1 2024" or "1st quarter 2024".
+func seqYearQuarter(locale language.Tag, opts Options) *symbols.Seq {
+	return symbols.NewSeq(locale).Add(opts.Quarter.symbol(), symbols.TxtSpace, opts.Year.symbol())
+}
+
+func seqYearQuarterPersian(locale language.Tag, opts Options) *symbols.Seq {
+	return seqYearQuarter(locale, opts)
+}
+
+func seqYearQuarterBuddhist(locale language.Tag, opts Options) *symbols.Seq {
+	return seqYearQuarter(locale, opts)
+}

--- a/internal/cldr/fmt.go
+++ b/internal/cldr/fmt.go
@@ -120,3 +120,33 @@ type SecondTwoDigit Digits
 func (s SecondTwoDigit) Format(b *strings.Builder, t TimeReader) {
 	Digits(s).appendTwoDigit(b, t.Second())
 }
+
+// QuarterShort formats the quarter in a short form like Q1.
+type QuarterShort Digits
+
+func (q QuarterShort) Format(b *strings.Builder, t TimeReader) {
+	quarter := (int(t.Month())-1)/3 + 1
+	b.WriteByte('Q')
+	Digits(q).appendNumeric(b, quarter)
+}
+
+// QuarterLong formats the quarter in a long form like 1st quarter.
+type QuarterLong Digits
+
+func (q QuarterLong) Format(b *strings.Builder, t TimeReader) {
+	quarter := (int(t.Month())-1)/3 + 1
+	Digits(q).appendNumeric(b, quarter)
+	var suffix string
+	switch quarter {
+	case 1:
+		suffix = "st"
+	case 2:
+		suffix = "nd"
+	case 3:
+		suffix = "rd"
+	default:
+		suffix = "th"
+	}
+	b.WriteString(suffix)
+	b.WriteString(" quarter")
+}

--- a/internal/symbols/symbols.go
+++ b/internal/symbols/symbols.go
@@ -73,6 +73,8 @@ const (
 	Symbol_E     // E, weekday short
 	Symbol_EEEE  // EEEE, weekday long
 	Symbol_EEEEE // EEEEE, weekday narrow
+	Symbol_QQQ   // QQQ, quarter short
+	Symbol_QQQQ  // QQQQ, quarter long
 )
 
 func (s Symbol) String() string {
@@ -223,6 +225,10 @@ func (s *Seq) Func() func(cldr.TimeReader) string {
 		case Symbol_EEEEE:
 			names := cldr.WeekdayNames(s.locale.String(), "narrow")
 			symFmt = cldr.Weekday(names)
+		case Symbol_QQQ:
+			symFmt = cldr.QuarterShort(digits)
+		case Symbol_QQQQ:
+			symFmt = cldr.QuarterLong(digits)
 		case MonthUnit:
 			symFmt = cldr.Text(cldr.UnitName(s.locale).Month)
 		case DayUnit:

--- a/intl.go
+++ b/intl.go
@@ -299,6 +299,76 @@ func ParseMonth(s string) (Month, error) {
 	}
 }
 
+// Quarter represents the format for displaying quarters.
+type Quarter byte
+
+const (
+	QuarterUnd Quarter = iota
+	QuarterShort
+	QuarterLong
+)
+
+// MustParseQuarter converts a string representation of a quarter format to the [Quarter] type.
+// It panics if the input string is not a valid quarter format.
+func MustParseQuarter(s string) Quarter {
+	v, err := ParseQuarter(s)
+	if err != nil {
+		panic(err)
+	}
+
+	return v
+}
+
+// String returns the string representation of the Quarter format.
+// It converts the Quarter constant to its corresponding string value.
+//
+// Returns:
+//   - "short" for [QuarterShort]
+//   - "long" for [QuarterLong]
+//   - "" for any other value (including [QuarterUnd])
+func (q Quarter) String() string {
+	switch q {
+	default:
+		return ""
+	case QuarterShort:
+		return "short"
+	case QuarterLong:
+		return "long"
+	}
+}
+
+func (q Quarter) und() bool   { return q == QuarterUnd }
+func (q Quarter) short() bool { return q == QuarterShort }
+
+func (q Quarter) symbol() symbols.Symbol {
+	if q == QuarterLong {
+		return symbols.Symbol_QQQQ
+	}
+
+	return symbols.Symbol_QQQ
+}
+
+// ParseQuarter converts a string representation of a quarter format to the [Quarter] type.
+//
+// Parameters:
+//   - s: A string representing the quarter format. Valid values are "long", "short", or an empty string.
+//
+// Returns:
+//   - Quarter: The corresponding [Quarter] constant ([QuarterLong], [QuarterShort], or [QuarterUnd]).
+//   - error: An error if the input string is not a valid quarter format.
+func ParseQuarter(s string) (Quarter, error) {
+	switch s {
+	default:
+		return QuarterUnd, fmt.Errorf(`bad quarter value "%s", want "long", "short" or ""`, s)
+	case "":
+		return QuarterUnd, nil
+	case "short":
+		return QuarterShort, nil
+	case "long":
+		return QuarterLong, nil
+	}
+}
+
 // Day represents the format for displaying days.
 type Day byte
 
@@ -672,6 +742,7 @@ type Options struct {
 	Era     Era
 	Year    Year
 	Month   Month
+	Quarter Quarter
 	Day     Day
 	Weekday Weekday
 	Hour    Hour
@@ -740,6 +811,8 @@ func gregorianDateTimeFormat(locale language.Tag, opts Options) fmtFunc {
 		seq = seqYearMonthDay(locale, opts)
 	case !opts.Year.und() && !opts.Month.und():
 		seq = seqYearMonth(locale, opts)
+	case !opts.Year.und() && !opts.Quarter.und():
+		seq = seqYearQuarter(locale, opts)
 	case !opts.Year.und() && !opts.Day.und():
 		seq = seqYearDay(locale, opts)
 	case !opts.Year.und():
@@ -802,6 +875,8 @@ func persianDateTimeFormat(locale language.Tag, opts Options) fmtFunc {
 		seq = seqYearMonthDayPersian(locale, opts)
 	case !opts.Year.und() && !opts.Month.und():
 		seq = seqYearMonthPersian(locale, opts)
+	case !opts.Year.und() && !opts.Quarter.und():
+		seq = seqYearQuarterPersian(locale, opts)
 	case !opts.Year.und() && !opts.Day.und():
 		seq = seqYearDayPersian(locale, opts)
 	case !opts.Year.und():
@@ -869,6 +944,8 @@ func buddhistDateTimeFormat(locale language.Tag, opts Options) fmtFunc {
 		seq = seqYearMonthDayBuddhist(locale, opts)
 	case !opts.Year.und() && !opts.Month.und():
 		seq = seqYearMonthBuddhist(locale, opts)
+	case !opts.Year.und() && !opts.Quarter.und():
+		seq = seqYearQuarterBuddhist(locale, opts)
 	case !opts.Year.und() && !opts.Day.und():
 		seq = seqYearDayBuddhist(locale, opts)
 	case !opts.Year.und():

--- a/layout.go
+++ b/layout.go
@@ -51,6 +51,12 @@ func ParseLayout(layout string) (Options, error) {
 			default:
 				opts.Month = MonthNarrow
 			}
+		case 'Q':
+			if count >= 4 {
+				opts.Quarter = QuarterLong
+			} else {
+				opts.Quarter = QuarterShort
+			}
 		case 'd':
 			if count == 2 {
 				opts.Day = Day2Digit

--- a/layout_test.go
+++ b/layout_test.go
@@ -18,14 +18,35 @@ func TestDateTimeFormat_Layout_Hms(t *testing.T) {
 	}
 }
 
-func TestDateTimeFormat_Layout_yMMMMEEEEd(t *testing.T) {
+func TestDateTimeFormat_Layout_Patterns(t *testing.T) {
 	t.Parallel()
 
 	date := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
-	got := NewDateTimeFormatLayout(language.English, "yMMMMEEEEd").Format(date)
 
-	want := "Tuesday, January 2, 2024"
-	if got != want {
-		t.Fatalf("want %q got %q", want, got)
+	tests := []struct {
+		layout string
+		want   string
+	}{
+		{"y", "2024"},
+		{"yM", "1/2024"},
+		{"yMEd", "Tue, 1/2/2024"},
+		{"yMMM", "Jan/2024"},
+		{"yMMMEd", "Tue, Jan 2, 2024"},
+		{"yMMMM", "January/2024"},
+		{"yMMMMEEEEd", "Tuesday, January 2, 2024"},
+		{"yMMMMd", "January 2, 2024"},
+		{"yMMMd", "Jan 2, 2024"},
+		{"yMd", "1/2/2024"},
+		{"yQQQ", "Q1 2024"},
+		{"yQQQQ", "1st quarter 2024"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.layout, func(t *testing.T) {
+			got := NewDateTimeFormatLayout(language.English, tt.layout).Format(date)
+			if got != tt.want {
+				t.Fatalf("want %q got %q", tt.want, got)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- support quarter formatting via new `Quarter` option and symbols
- allow layouts with `Q` to parse and format year-quarter patterns
- expand layout tests to cover common skeleton patterns including `yQQQ` and `yQQQQ`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689469007234832fac5741fac67be1ae