### PR TITLE
Add support for additional date/time skeletons

### DIFF
--- a/fmt_q.go
+++ b/fmt_q.go
@@ -1,0 +1,18 @@
+package intl
+
+import (
+	"go.expect.digital/intl/internal/symbols"
+	"golang.org/x/text/language"
+)
+
+func seqQuarter(locale language.Tag, opt Quarter) *symbols.Seq {
+	return symbols.NewSeq(locale).Add(opt.symbol())
+}
+
+func seqQuarterPersian(locale language.Tag, opt Quarter) *symbols.Seq {
+	return seqQuarter(locale, opt)
+}
+
+func seqQuarterBuddhist(locale language.Tag, opt Quarter) *symbols.Seq {
+	return seqQuarter(locale, opt)
+}

--- a/intl.go
+++ b/intl.go
@@ -817,6 +817,8 @@ func gregorianDateTimeFormat(locale language.Tag, opts Options) fmtFunc {
 		seq = seqYearDay(locale, opts)
 	case !opts.Year.und():
 		seq = seqYear(locale, opts.Year)
+	case !opts.Quarter.und():
+		seq = seqQuarter(locale, opts.Quarter)
 	case !opts.Month.und() && !opts.Weekday.und() && !opts.Hour.und() && !opts.Minute.und():
 		seq = seqMonthWeekdayTime(locale, opts)
 	case !opts.Month.und() && !opts.Day.und() && !opts.Weekday.und():
@@ -881,6 +883,8 @@ func persianDateTimeFormat(locale language.Tag, opts Options) fmtFunc {
 		seq = seqYearDayPersian(locale, opts)
 	case !opts.Year.und():
 		seq = seqYearPersian(locale, opts.Year)
+	case !opts.Quarter.und():
+		seq = seqQuarterPersian(locale, opts.Quarter)
 	case !opts.Month.und() && !opts.Weekday.und() && !opts.Hour.und() && !opts.Minute.und():
 		seq = seqMonthWeekdayTime(locale, opts)
 	case !opts.Month.und() && !opts.Day.und() && !opts.Weekday.und():
@@ -950,6 +954,8 @@ func buddhistDateTimeFormat(locale language.Tag, opts Options) fmtFunc {
 		seq = seqYearDayBuddhist(locale, opts)
 	case !opts.Year.und():
 		seq = seqYearBuddhist(locale, opts)
+	case !opts.Quarter.und():
+		seq = seqQuarterBuddhist(locale, opts.Quarter)
 	case !opts.Month.und() && !opts.Weekday.und() && !opts.Hour.und() && !opts.Minute.und():
 		seq = seqMonthWeekdayTime(locale, opts)
 	case !opts.Month.und() && !opts.Day.und() && !opts.Weekday.und():

--- a/layout.go
+++ b/layout.go
@@ -72,7 +72,7 @@ func ParseLayout(layout string) (Options, error) {
 			default:
 				opts.Weekday = WeekdayShort
 			}
-		case 'H', 'h':
+		case 'H', 'h', 'j':
 			if count == 2 {
 				opts.Hour = Hour2Digit
 			} else {

--- a/layout_test.go
+++ b/layout_test.go
@@ -39,6 +39,15 @@ func TestDateTimeFormat_Layout_Patterns(t *testing.T) {
 		{"yMd", "1/2/2024"},
 		{"yQQQ", "Q1 2024"},
 		{"yQQQQ", "1st quarter 2024"},
+		{"QQQ", "Q1"},
+		{"QQQQ", "1st quarter"},
+		{"d", "2"},
+		{"j", "3"},
+		{"jm", "3:4"},
+		{"jms", "3:4:5"},
+		{"m", "4"},
+		{"ms", "4:5"},
+		{"s", "5"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- handle `j` hour skeleton in layout parsing
- add quarter-only formatter and mapping for Gregorian, Persian and Buddhist calendars
- extend layout tests for QQQ, QQQQ, d, j, jm, jms, m, ms, and s

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68946c9b0c74832f9b8318c99632baec