### PR TITLE
chore: update module path to github.com/boltegg/intl

### DIFF
--- a/fmt_d.go
+++ b/fmt_d.go
@@ -1,8 +1,8 @@
 package intl
 
 import (
-	"go.expect.digital/intl/internal/cldr"
-	"go.expect.digital/intl/internal/symbols"
+	"github.com/boltegg/intl/internal/cldr"
+	"github.com/boltegg/intl/internal/symbols"
 	"golang.org/x/text/language"
 )
 

--- a/fmt_e.go
+++ b/fmt_e.go
@@ -1,7 +1,7 @@
 package intl
 
 import (
-	"go.expect.digital/intl/internal/symbols"
+	"github.com/boltegg/intl/internal/symbols"
 	"golang.org/x/text/language"
 )
 

--- a/fmt_ehm.go
+++ b/fmt_ehm.go
@@ -1,7 +1,7 @@
 package intl
 
 import (
-	"go.expect.digital/intl/internal/symbols"
+	"github.com/boltegg/intl/internal/symbols"
 	"golang.org/x/text/language"
 )
 

--- a/fmt_gd.go
+++ b/fmt_gd.go
@@ -1,8 +1,8 @@
 package intl
 
 import (
-	"go.expect.digital/intl/internal/cldr"
-	"go.expect.digital/intl/internal/symbols"
+	"github.com/boltegg/intl/internal/cldr"
+	"github.com/boltegg/intl/internal/symbols"
 	"golang.org/x/text/language"
 )
 

--- a/fmt_gm.go
+++ b/fmt_gm.go
@@ -1,8 +1,8 @@
 package intl
 
 import (
-	"go.expect.digital/intl/internal/cldr"
-	"go.expect.digital/intl/internal/symbols"
+	"github.com/boltegg/intl/internal/cldr"
+	"github.com/boltegg/intl/internal/symbols"
 	"golang.org/x/text/language"
 )
 

--- a/fmt_gmd.go
+++ b/fmt_gmd.go
@@ -1,8 +1,8 @@
 package intl
 
 import (
-	"go.expect.digital/intl/internal/cldr"
-	"go.expect.digital/intl/internal/symbols"
+	"github.com/boltegg/intl/internal/cldr"
+	"github.com/boltegg/intl/internal/symbols"
 	"golang.org/x/text/language"
 )
 

--- a/fmt_gy.go
+++ b/fmt_gy.go
@@ -1,8 +1,8 @@
 package intl
 
 import (
-	"go.expect.digital/intl/internal/cldr"
-	"go.expect.digital/intl/internal/symbols"
+	"github.com/boltegg/intl/internal/cldr"
+	"github.com/boltegg/intl/internal/symbols"
 	"golang.org/x/text/language"
 )
 

--- a/fmt_gyd.go
+++ b/fmt_gyd.go
@@ -1,8 +1,8 @@
 package intl
 
 import (
-	"go.expect.digital/intl/internal/cldr"
-	"go.expect.digital/intl/internal/symbols"
+	"github.com/boltegg/intl/internal/cldr"
+	"github.com/boltegg/intl/internal/symbols"
 	"golang.org/x/text/language"
 )
 

--- a/fmt_gym.go
+++ b/fmt_gym.go
@@ -1,8 +1,8 @@
 package intl
 
 import (
-	"go.expect.digital/intl/internal/cldr"
-	"go.expect.digital/intl/internal/symbols"
+	"github.com/boltegg/intl/internal/cldr"
+	"github.com/boltegg/intl/internal/symbols"
 	"golang.org/x/text/language"
 )
 

--- a/fmt_gymd.go
+++ b/fmt_gymd.go
@@ -1,8 +1,8 @@
 package intl
 
 import (
-	"go.expect.digital/intl/internal/cldr"
-	"go.expect.digital/intl/internal/symbols"
+	"github.com/boltegg/intl/internal/cldr"
+	"github.com/boltegg/intl/internal/symbols"
 	"golang.org/x/text/language"
 )
 

--- a/fmt_h.go
+++ b/fmt_h.go
@@ -1,7 +1,7 @@
 package intl
 
 import (
-	"go.expect.digital/intl/internal/symbols"
+	"github.com/boltegg/intl/internal/symbols"
 	"golang.org/x/text/language"
 )
 

--- a/fmt_hm.go
+++ b/fmt_hm.go
@@ -1,7 +1,7 @@
 package intl
 
 import (
-	"go.expect.digital/intl/internal/symbols"
+	"github.com/boltegg/intl/internal/symbols"
 	"golang.org/x/text/language"
 )
 

--- a/fmt_hms.go
+++ b/fmt_hms.go
@@ -1,7 +1,7 @@
 package intl
 
 import (
-	"go.expect.digital/intl/internal/symbols"
+	"github.com/boltegg/intl/internal/symbols"
 	"golang.org/x/text/language"
 )
 

--- a/fmt_m.go
+++ b/fmt_m.go
@@ -1,8 +1,8 @@
 package intl
 
 import (
-	"go.expect.digital/intl/internal/cldr"
-	"go.expect.digital/intl/internal/symbols"
+	"github.com/boltegg/intl/internal/cldr"
+	"github.com/boltegg/intl/internal/symbols"
 	"golang.org/x/text/language"
 )
 

--- a/fmt_md.go
+++ b/fmt_md.go
@@ -1,8 +1,8 @@
 package intl
 
 import (
-	"go.expect.digital/intl/internal/cldr"
-	"go.expect.digital/intl/internal/symbols"
+	"github.com/boltegg/intl/internal/cldr"
+	"github.com/boltegg/intl/internal/symbols"
 	"golang.org/x/text/language"
 )
 

--- a/fmt_med.go
+++ b/fmt_med.go
@@ -1,7 +1,7 @@
 package intl
 
 import (
-	"go.expect.digital/intl/internal/symbols"
+	"github.com/boltegg/intl/internal/symbols"
 	"golang.org/x/text/language"
 )
 

--- a/fmt_minute.go
+++ b/fmt_minute.go
@@ -1,7 +1,7 @@
 package intl
 
 import (
-	"go.expect.digital/intl/internal/symbols"
+	"github.com/boltegg/intl/internal/symbols"
 	"golang.org/x/text/language"
 )
 

--- a/fmt_ms.go
+++ b/fmt_ms.go
@@ -1,7 +1,7 @@
 package intl
 
 import (
-	"go.expect.digital/intl/internal/symbols"
+	"github.com/boltegg/intl/internal/symbols"
 	"golang.org/x/text/language"
 )
 

--- a/fmt_q.go
+++ b/fmt_q.go
@@ -1,7 +1,7 @@
 package intl
 
 import (
-	"go.expect.digital/intl/internal/symbols"
+	"github.com/boltegg/intl/internal/symbols"
 	"golang.org/x/text/language"
 )
 

--- a/fmt_s.go
+++ b/fmt_s.go
@@ -1,7 +1,7 @@
 package intl
 
 import (
-	"go.expect.digital/intl/internal/symbols"
+	"github.com/boltegg/intl/internal/symbols"
 	"golang.org/x/text/language"
 )
 

--- a/fmt_y.go
+++ b/fmt_y.go
@@ -1,8 +1,8 @@
 package intl
 
 import (
-	"go.expect.digital/intl/internal/cldr"
-	"go.expect.digital/intl/internal/symbols"
+	"github.com/boltegg/intl/internal/cldr"
+	"github.com/boltegg/intl/internal/symbols"
 	"golang.org/x/text/language"
 )
 

--- a/fmt_yd.go
+++ b/fmt_yd.go
@@ -1,8 +1,8 @@
 package intl
 
 import (
-	"go.expect.digital/intl/internal/cldr"
-	"go.expect.digital/intl/internal/symbols"
+	"github.com/boltegg/intl/internal/cldr"
+	"github.com/boltegg/intl/internal/symbols"
 	"golang.org/x/text/language"
 )
 

--- a/fmt_ym.go
+++ b/fmt_ym.go
@@ -1,8 +1,8 @@
 package intl
 
 import (
-	"go.expect.digital/intl/internal/cldr"
-	"go.expect.digital/intl/internal/symbols"
+	"github.com/boltegg/intl/internal/cldr"
+	"github.com/boltegg/intl/internal/symbols"
 	"golang.org/x/text/language"
 )
 

--- a/fmt_ymd.go
+++ b/fmt_ymd.go
@@ -1,8 +1,8 @@
 package intl
 
 import (
-	"go.expect.digital/intl/internal/cldr"
-	"go.expect.digital/intl/internal/symbols"
+	"github.com/boltegg/intl/internal/cldr"
+	"github.com/boltegg/intl/internal/symbols"
 	"golang.org/x/text/language"
 )
 

--- a/fmt_ymde.go
+++ b/fmt_ymde.go
@@ -1,7 +1,7 @@
 package intl
 
 import (
-	"go.expect.digital/intl/internal/symbols"
+	"github.com/boltegg/intl/internal/symbols"
 	"golang.org/x/text/language"
 )
 

--- a/fmt_yq.go
+++ b/fmt_yq.go
@@ -1,7 +1,7 @@
 package intl
 
 import (
-	"go.expect.digital/intl/internal/symbols"
+	"github.com/boltegg/intl/internal/symbols"
 	"golang.org/x/text/language"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module go.expect.digital/intl
+module github.com/boltegg/intl
 
 go 1.23.0
 

--- a/internal/gen/gen.go
+++ b/internal/gen/gen.go
@@ -15,7 +15,7 @@ import (
 	"text/template"
 	"time"
 
-	"go.expect.digital/intl/internal/gen/cldr"
+	"github.com/boltegg/intl/internal/gen/cldr"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )

--- a/internal/symbols/symbols.go
+++ b/internal/symbols/symbols.go
@@ -1,7 +1,7 @@
 package symbols
 
 import (
-	"go.expect.digital/intl/internal/cldr"
+	"github.com/boltegg/intl/internal/cldr"
 	"golang.org/x/text/language"
 )
 

--- a/internal/tst/main.go
+++ b/internal/tst/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"go.expect.digital/intl"
+	"github.com/boltegg/intl"
 	"golang.org/x/text/language"
 )
 

--- a/intl.go
+++ b/intl.go
@@ -27,9 +27,9 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/boltegg/intl/internal/cldr"
+	"github.com/boltegg/intl/internal/symbols"
 	ptime "github.com/yaa110/go-persian-calendar"
-	"go.expect.digital/intl/internal/cldr"
-	"go.expect.digital/intl/internal/symbols"
 	"golang.org/x/text/language"
 )
 

--- a/intl_test.go
+++ b/intl_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"go.expect.digital/intl/internal/cldr"
+	"github.com/boltegg/intl/internal/cldr"
 	"golang.org/x/text/language"
 )
 


### PR DESCRIPTION
## Summary
- update module path from go.expect.digital/intl to github.com/boltegg/intl
- adjust internal imports to reflect new module path

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68948b9b4c70832f8aa09043a6d014e4