### PR TITLE
feat: add Ukrainian quarter names

### DIFF
--- a/fmt_yq.go
+++ b/fmt_yq.go
@@ -7,7 +7,12 @@ import (
 
 // seqYearQuarter formats a year and quarter, e.g. "Q1 2024" or "1st quarter 2024".
 func seqYearQuarter(locale language.Tag, opts Options) *symbols.Seq {
-	return symbols.NewSeq(locale).Add(opts.Quarter.symbol(), symbols.TxtSpace, opts.Year.symbol())
+	seq := symbols.NewSeq(locale).Add(opts.Quarter.symbol(), symbols.TxtSpace, opts.Year.symbol())
+	if base, _ := locale.Base(); base.String() == "uk" && !opts.Quarter.short() {
+		seq.Add(symbols.TxtNNBSP, symbols.Txtр, '.')
+	}
+
+	return seq
 }
 
 func seqYearQuarterPersian(locale language.Tag, opts Options) *symbols.Seq {

--- a/internal/symbols/symbols.go
+++ b/internal/symbols/symbols.go
@@ -226,9 +226,9 @@ func (s *Seq) Func() func(cldr.TimeReader) string {
 			names := cldr.WeekdayNames(s.locale.String(), "narrow")
 			symFmt = cldr.Weekday(names)
 		case Symbol_QQQ:
-			symFmt = cldr.QuarterShort(digits)
+			symFmt = cldr.QuarterShort(s.locale, digits)
 		case Symbol_QQQQ:
-			symFmt = cldr.QuarterLong(digits)
+			symFmt = cldr.QuarterLong(s.locale, digits)
 		case MonthUnit:
 			symFmt = cldr.Text(cldr.UnitName(s.locale).Month)
 		case DayUnit:

--- a/ukrainian_test.go
+++ b/ukrainian_test.go
@@ -23,6 +23,10 @@ func TestDateTimeFormat_Ukrainian(t *testing.T) {
 		{"WeekdayLongMonthDay", Options{Weekday: WeekdayLong, Month: MonthLong, Day: DayNumeric}, "вівторок, 2 січня"},
 		{"YearMonthDay", Options{Year: YearNumeric, Month: MonthLong, Day: DayNumeric}, "2 січня 2024 р."},
 		{"YearMonth", Options{Year: YearNumeric, Month: MonthLong}, "січень 2024 р."},
+		{"QuarterShort", Options{Quarter: QuarterShort}, "1-й кв."},
+		{"YearQuarterShort", Options{Year: YearNumeric, Quarter: QuarterShort}, "1-й кв. 2024"},
+		{"QuarterLong", Options{Quarter: QuarterLong}, "1-й квартал"},
+		{"YearQuarterLong", Options{Year: YearNumeric, Quarter: QuarterLong}, "1-й квартал 2024 р."},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- add locale-aware quarter formatting with Ukrainian strings
- ensure year+quarter layouts append Ukrainian year suffix
- test Ukrainian quarter formatting

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68948f8bcdc8832f984f8cee8220958b