### PR TITLE
feat: add russian language

### DIFF
--- a/fmt_m.go
+++ b/fmt_m.go
@@ -13,7 +13,7 @@ func seqMonth(locale language.Tag, opt Month) *symbols.Seq {
 	switch lang {
 	case cldr.BR, cldr.FO, cldr.GA, cldr.LT, cldr.UZ:
 		seq.Add(symbols.Symbol_MM)
-	case cldr.UK:
+	case cldr.UK, cldr.RU:
 		seq.Add(opt.symbolStandAlone())
 	case cldr.MN:
 		seq.Add(symbols.Symbol_LLLLL)

--- a/fmt_md.go
+++ b/fmt_md.go
@@ -147,12 +147,18 @@ func seqMonthDay(locale language.Tag, opts Options) *symbols.Seq {
 		return seq.Add(symbols.Symbol_d, '.', symbols.Symbol_M, '.')
 	case cldr.SQ:
 		return seq.Add(symbols.Symbol_d, '.', symbols.Symbol_M)
-	case cldr.RO, cldr.RU:
+	case cldr.RO:
 		if opts.Month.numeric() && opts.Day.numeric() {
 			return seq.Add(symbols.Symbol_dd, '.', symbols.Symbol_MM)
 		}
 
 		return seq.Add(day, '.', month)
+	case cldr.RU:
+		if opts.Month.numeric() && opts.Day.numeric() {
+			return seq.Add(symbols.Symbol_dd, '.', symbols.Symbol_MM)
+		}
+
+		return seq.Add(day, symbols.TxtSpace, month)
 	case cldr.SR:
 		if opts.Month.numeric() && opts.Day.numeric() {
 			return seq.Add(day, '.', ' ', month, '.')

--- a/fmt_ym.go
+++ b/fmt_ym.go
@@ -98,8 +98,14 @@ func seqYearMonth(locale language.Tag, opts Options) *symbols.Seq {
 		return seq.Add(month, '/', year)
 	case cldr.AR:
 		return seq.Add(month, symbols.Txt02, year)
-	case cldr.AZ, cldr.CV, cldr.FO, cldr.HY, cldr.KK, cldr.KU, cldr.OS, cldr.PL, cldr.RO, cldr.RU, cldr.TK, cldr.TT:
+	case cldr.AZ, cldr.CV, cldr.FO, cldr.HY, cldr.KK, cldr.KU, cldr.OS, cldr.PL, cldr.RO, cldr.TK, cldr.TT:
 		return seq.Add(symbols.Symbol_MM, '.', year)
+	case cldr.RU:
+		if opts.Month.numeric() || opts.Month.twoDigit() {
+			return seq.Add(symbols.Symbol_MM, '.', year)
+		}
+
+		return seq.Add(opts.Month.symbolStandAlone(), ' ', year, symbols.TxtNNBSP, symbols.Txt00)
 	case cldr.UK:
 		if opts.Month.numeric() || opts.Month.twoDigit() {
 			return seq.Add(symbols.Symbol_MM, '.', year)

--- a/fmt_ymd.go
+++ b/fmt_ymd.go
@@ -397,7 +397,7 @@ func seqYearMonthDay(locale language.Tag, opts Options) *symbols.Seq {
 		// year=2-digit,month=2-digit,day=numeric,out=2. 01. 24
 		// year=2-digit,month=2-digit,day=2-digit,out=02. 01. 24
 		return seq.Add(day, '.', ' ', month, '.', ' ', year)
-	case cldr.CV, cldr.FO, cldr.KU, cldr.RO, cldr.RU, cldr.TK, cldr.TT:
+	case cldr.CV, cldr.FO, cldr.KU, cldr.RO, cldr.TK, cldr.TT:
 		// year=numeric,month=numeric,day=numeric,out=02.01.2024
 		// year=numeric,month=numeric,day=2-digit,out=02.1.2024
 		// year=numeric,month=2-digit,day=numeric,out=2.01.2024
@@ -411,6 +411,12 @@ func seqYearMonthDay(locale language.Tag, opts Options) *symbols.Seq {
 		}
 
 		return seq.Add(day, '.', month, '.', year)
+	case cldr.RU:
+		if opts.Month.numeric() && opts.Day.numeric() {
+			return seq.Add(symbols.Symbol_dd, '.', symbols.Symbol_MM, '.', year)
+		}
+
+		return seq.Add(day, ' ', month, ' ', year, symbols.TxtNNBSP, symbols.Txt00)
 	case cldr.DZ, cldr.SI: // noop
 		// year=numeric,month=numeric,day=numeric,out=2024-1-2
 		// year=numeric,month=numeric,day=2-digit,out=2024-1-02

--- a/fmt_yq.go
+++ b/fmt_yq.go
@@ -10,6 +10,8 @@ func seqYearQuarter(locale language.Tag, opts Options) *symbols.Seq {
 	seq := symbols.NewSeq(locale).Add(opts.Quarter.symbol(), symbols.TxtSpace, opts.Year.symbol())
 	if base, _ := locale.Base(); base.String() == "uk" && !opts.Quarter.short() {
 		seq.Add(symbols.TxtNNBSP, symbols.Txtр, '.')
+	} else if base.String() == "ru" && !opts.Quarter.short() {
+		seq.Add(symbols.TxtNNBSP, symbols.Txt00)
 	}
 
 	return seq

--- a/internal/cldr/fmt.go
+++ b/internal/cldr/fmt.go
@@ -137,7 +137,7 @@ func QuarterShort(locale language.Tag, digits Digits) FmtFunc {
 func (q quarterShort) Format(b *strings.Builder, t TimeReader) {
 	quarter := (int(t.Month())-1)/3 + 1
 
-	if base, _ := q.locale.Base(); base.String() == "uk" {
+	if base, _ := q.locale.Base(); base.String() == "uk" || base.String() == "ru" {
 		Digits(q.digits).appendNumeric(b, quarter)
 		b.WriteString("-й кв.")
 		return
@@ -161,7 +161,7 @@ func QuarterLong(locale language.Tag, digits Digits) FmtFunc {
 func (q quarterLong) Format(b *strings.Builder, t TimeReader) {
 	quarter := (int(t.Month())-1)/3 + 1
 
-	if base, _ := q.locale.Base(); base.String() == "uk" {
+	if base, _ := q.locale.Base(); base.String() == "uk" || base.String() == "ru" {
 		Digits(q.digits).appendNumeric(b, quarter)
 		b.WriteString("-й квартал")
 		return

--- a/internal/cldr/weekday.go
+++ b/internal/cldr/weekday.go
@@ -14,6 +14,11 @@ var weekdayData = map[string]map[string]CalendarWeekdays{
 		"wide":        {"неділя", "понеділок", "вівторок", "середа", "четвер", "пʼятниця", "субота"},
 		"narrow":      {"Н", "П", "В", "С", "Ч", "П", "С"},
 	},
+	"ru": {
+		"abbreviated": {"вс", "пн", "вт", "ср", "чт", "пт", "сб"},
+		"wide":        {"воскресенье", "понедельник", "вторник", "среда", "четверг", "пятница", "суббота"},
+		"narrow":      {"В", "П", "В", "С", "Ч", "П", "С"},
+	},
 }
 
 // WeekdayNames returns localized weekday names for the given locale and width.

--- a/russian_test.go
+++ b/russian_test.go
@@ -1,0 +1,42 @@
+package intl
+
+import (
+	"testing"
+	"time"
+
+	"golang.org/x/text/language"
+)
+
+func TestDateTimeFormat_Russian(t *testing.T) {
+	t.Parallel()
+	date := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	locale := language.MustParse("ru")
+
+	tests := []struct {
+		name string
+		opts Options
+		want string
+	}{
+		{"Month", Options{Month: MonthLong}, "январь"},
+		{"MonthDay", Options{Month: MonthLong, Day: DayNumeric}, "2 января"},
+		{"WeekdayMonthDay", Options{Weekday: WeekdayShort, Month: MonthLong, Day: DayNumeric}, "вт, 2 января"},
+		{"WeekdayLongMonthDay", Options{Weekday: WeekdayLong, Month: MonthLong, Day: DayNumeric}, "вторник, 2 января"},
+		{"YearMonthDay", Options{Year: YearNumeric, Month: MonthLong, Day: DayNumeric}, "2 января 2024 г."},
+		{"YearMonth", Options{Year: YearNumeric, Month: MonthLong}, "январь 2024 г."},
+		{"QuarterShort", Options{Quarter: QuarterShort}, "1-й кв."},
+		{"YearQuarterShort", Options{Year: YearNumeric, Quarter: QuarterShort}, "1-й кв. 2024"},
+		{"QuarterLong", Options{Quarter: QuarterLong}, "1-й квартал"},
+		{"YearQuarterLong", Options{Year: YearNumeric, Quarter: QuarterLong}, "1-й квартал 2024 г."},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := NewDateTimeFormat(locale, tt.opts).Format(date)
+			if got != tt.want {
+				t.Fatalf("want %q got %q", tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add Russian locale and weekday data
- support Russian-specific date and quarter formatting
- add tests for Russian

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6894acd334c0832fb37569e151892bca