### PR TITLE
Fix Russian abbreviated month formatting

### DIFF
--- a/internal/cldr/cldr.go
+++ b/internal/cldr/cldr.go
@@ -5,6 +5,27 @@ import "golang.org/x/text/language"
 func MonthNames(locale string, context, width string) CalendarMonths {
 	indexes := MonthLookup[locale]
 
+	// Russian locales mix abbreviated and wide month names when formatting
+	// dates with the abbreviated width. The base data uses the abbreviated
+	// set, but certain months (March, May, June, July) should use the wide
+	// genitive forms. Adjust the result accordingly.
+	if width == "abbreviated" && context == "format" {
+		if base, _ := language.Make(locale).Base(); base.String() == "ru" {
+			var out CalendarMonths
+			if v := int(indexes[0]); v > 0 && v < len(CalendarMonthNames) {
+				out = CalendarMonthNames[v]
+			}
+			if v := int(indexes[2]); v > 0 && v < len(CalendarMonthNames) {
+				wide := CalendarMonthNames[v]
+				out[2] = wide[2] // March
+				out[4] = wide[4] // May
+				out[5] = wide[5] // June
+				out[6] = wide[6] // July
+			}
+			return out
+		}
+	}
+
 	var i int
 
 	// "abbreviated" width index is 0

--- a/internal/cldr/data.go
+++ b/internal/cldr/data.go
@@ -2804,18 +2804,16 @@ var MonthLookup = map[string]monthIndexes{
 	"rof":            {527, 527, 528, 528, 0, 529},
 	"rof-TZ":         {527, 527, 528, 528, 0, 529},
 	"root":           {0, 0, 0, 0, 0, 0},
-	// Use wide month names when formatting dates with abbreviated width
-	// for Russian locales. CLDR specifies genitive month names ("июня",
-	// "июля") in the d MMM y pattern, but the previous data pointed to the
-	// abbreviated forms ("июн.", "июл.").  Adjusting the index ensures the
-	// correct wide forms are returned for format/abbreviated requests.
-	"ru":          {531, 532, 531, 95, 0, 96},
-	"ru-BY":       {531, 532, 531, 95, 0, 96},
-	"ru-KG":       {531, 532, 531, 95, 0, 96},
-	"ru-KZ":       {531, 532, 531, 95, 0, 96},
-	"ru-MD":       {531, 532, 531, 95, 0, 96},
-	"ru-RU":       {531, 532, 531, 95, 0, 96},
-	"ru-UA":       {531, 532, 531, 95, 0, 96},
+	// Russian month formatting mixes abbreviated and wide forms. The lookup
+	// points to the abbreviated month set; specific months are adjusted in
+	// code to match CLDR's format behavior.
+	"ru":          {532, 532, 531, 95, 0, 96},
+	"ru-BY":       {532, 532, 531, 95, 0, 96},
+	"ru-KG":       {532, 532, 531, 95, 0, 96},
+	"ru-KZ":       {532, 532, 531, 95, 0, 96},
+	"ru-MD":       {532, 532, 531, 95, 0, 96},
+	"ru-RU":       {532, 532, 531, 95, 0, 96},
+	"ru-UA":       {532, 532, 531, 95, 0, 96},
 	"rw":          {533, 533, 534, 534, 0, 0},
 	"rw-RW":       {533, 533, 534, 534, 0, 0},
 	"rwk":         {291, 291, 292, 292, 0, 3},


### PR DESCRIPTION
## Summary
- correct Russian month lookup to use abbreviated names
- mix wide and abbreviated month forms in MonthNames for Russian locales

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6894b719971c832f9d372dd38e953624