### PR TITLE
fix RU-UA quarter year suffix

### DIFF
--- a/fmt_yq.go
+++ b/fmt_yq.go
@@ -10,8 +10,10 @@ func seqYearQuarter(locale language.Tag, opts Options) *symbols.Seq {
 	seq := symbols.NewSeq(locale).Add(opts.Quarter.symbol(), symbols.TxtSpace, opts.Year.symbol())
 	if base, _ := locale.Base(); base.String() == "uk" && !opts.Quarter.short() {
 		seq.Add(symbols.TxtNNBSP, symbols.Txtр, '.')
-	} else if base.String() == "ru" && !opts.Quarter.short() {
-		seq.Add(symbols.TxtNNBSP, symbols.Txt00)
+	} else if base.String() == "ru" {
+		if region, _ := locale.Region(); region.String() == "UA" || !opts.Quarter.short() {
+			seq.Add(symbols.TxtNNBSP, symbols.Txt00)
+		}
 	}
 
 	return seq

--- a/russian_ua_test.go
+++ b/russian_ua_test.go
@@ -1,0 +1,21 @@
+package intl
+
+import (
+	"testing"
+	"time"
+
+	"golang.org/x/text/language"
+)
+
+func TestDateTimeFormat_RussianUkraine(t *testing.T) {
+	t.Parallel()
+
+	date := time.Date(2025, 4, 1, 0, 0, 0, 0, time.UTC)
+	locale := language.MustParse("ru-UA")
+
+	got := NewDateTimeFormat(locale, Options{Year: YearNumeric, Quarter: QuarterShort}).Format(date)
+	want := "2-й кв. 2025 г."
+	if got != want {
+		t.Fatalf("want %q got %q", want, got)
+	}
+}


### PR DESCRIPTION
## Summary
- ensure ru-UA quarter-with-year format adds narrow space and year marker
- add regression test for ru-UA quarter format

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6894ba82e7e0832fa1633f5510a09ce7