### PR TITLE
Handle weekday names for region locales

### DIFF
--- a/internal/cldr/weekday.go
+++ b/internal/cldr/weekday.go
@@ -1,5 +1,7 @@
 package cldr
 
+import "golang.org/x/text/language"
+
 // CalendarWeekdays stores localized weekday names.
 type CalendarWeekdays [7]string
 
@@ -22,12 +24,24 @@ var weekdayData = map[string]map[string]CalendarWeekdays{
 }
 
 // WeekdayNames returns localized weekday names for the given locale and width.
-// If locale is unknown, English names are returned.
+// If the exact locale is unknown, it falls back to the base language before
+// defaulting to English.
 func WeekdayNames(locale, width string) CalendarWeekdays {
 	if m, ok := weekdayData[locale]; ok {
 		if w, ok := m[width]; ok {
 			return w
 		}
+	}
+
+	lang, _ := language.Make(locale).Base()
+	if m, ok := weekdayData[lang.String()]; ok {
+		if w, ok := m[width]; ok {
+			return w
+		}
+	}
+
+	if w, ok := weekdayData["en"][width]; ok {
+		return w
 	}
 
 	return weekdayData["en"]["abbreviated"]

--- a/russian_ua_test.go
+++ b/russian_ua_test.go
@@ -19,3 +19,16 @@ func TestDateTimeFormat_RussianUkraine(t *testing.T) {
 		t.Fatalf("want %q got %q", want, got)
 	}
 }
+
+func TestDateTimeFormat_RussianUkraineWeekday(t *testing.T) {
+	t.Parallel()
+
+	date := time.Date(2024, 3, 27, 0, 0, 0, 0, time.UTC)
+	locale := language.MustParse("ru-UA")
+
+	got := NewDateTimeFormatLayout(locale, "E").Format(date)
+	want := "Ср"
+	if got != want {
+		t.Fatalf("want %q got %q", want, got)
+	}
+}

--- a/ukrainian_ua_test.go
+++ b/ukrainian_ua_test.go
@@ -1,0 +1,37 @@
+package intl
+
+import (
+	"testing"
+	"time"
+
+	"golang.org/x/text/language"
+)
+
+func TestDateTimeFormat_UkrainianUkraine(t *testing.T) {
+	t.Parallel()
+
+	locale := language.MustParse("uk-UA")
+
+	tests := []struct {
+		name   string
+		layout string
+		date   time.Time
+		want   string
+	}{
+		{"E", "E", time.Date(2024, 3, 27, 0, 0, 0, 0, time.UTC), "ср"},
+		{"MEd", "MEd", time.Date(2025, 3, 26, 0, 0, 0, 0, time.UTC), "ср, 26.03"},
+		{"yMMMEd", "yMMMEd", time.Date(2025, 11, 28, 0, 0, 0, 0, time.UTC), "пт, 28 лист. 2025 р."},
+		{"yMMMMEEEEd", "yMMMMEEEEd", time.Date(2025, 6, 3, 0, 0, 0, 0, time.UTC), "вівторок, 3 червня 2025 р."},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := NewDateTimeFormatLayout(locale, tt.layout).Format(tt.date)
+			if got != tt.want {
+				t.Fatalf("want %q got %q", tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- handle locale fallbacks when looking up weekday names
- add Ukrainian (Ukraine) layout tests
- cover weekday formatting for ru-UA

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6894bd81a7cc832fa9fdc133c8620b4f