### PR TITLE
Fix Ukrainian month formatting for single M patterns

### DIFF
--- a/internal/symbols/symbols.go
+++ b/internal/symbols/symbols.go
@@ -182,7 +182,13 @@ func (s *Seq) Func() func(cldr.TimeReader) string {
 		case Symbol_yy:
 			symFmt = cldr.YearTwoDigit(digits)
 		case Symbol_M:
-			symFmt = cldr.MonthNumeric(digits)
+			base, _ := s.locale.Base()
+			region, _ := s.locale.Region()
+			if base.String() == "uk" && region.String() == "UA" {
+				symFmt = cldr.MonthTwoDigit(digits)
+			} else {
+				symFmt = cldr.MonthNumeric(digits)
+			}
 		case Symbol_MM:
 			symFmt = cldr.MonthTwoDigit(digits)
 		case Symbol_MMM:

--- a/ukrainian_ua_test.go
+++ b/ukrainian_ua_test.go
@@ -18,6 +18,7 @@ func TestDateTimeFormat_UkrainianUkraine(t *testing.T) {
 		date   time.Time
 		want   string
 	}{
+		{"M", "M", time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC), "03"},
 		{"E", "E", time.Date(2024, 3, 27, 0, 0, 0, 0, time.UTC), "ср"},
 		{"MEd", "MEd", time.Date(2025, 3, 26, 0, 0, 0, 0, time.UTC), "ср, 26.03"},
 		{"yMMMEd", "yMMMEd", time.Date(2025, 11, 28, 0, 0, 0, 0, time.UTC), "пт, 28 лист. 2025 р."},


### PR DESCRIPTION
## Summary
- Ensure uk-UA locale uses two-digit month numbers for `M` patterns
- Add regression test for Ukrainian (Ukraine) month formatting

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6894c0600024832f957e841051da6a81