### PR TITLE
Handle ru-UA day without leading zero

### DIFF
--- a/fmt_ymd.go
+++ b/fmt_ymd.go
@@ -413,6 +413,10 @@ func seqYearMonthDay(locale language.Tag, opts Options) *symbols.Seq {
 		return seq.Add(day, '.', month, '.', year)
 	case cldr.RU:
 		if opts.Month.numeric() && opts.Day.numeric() {
+			if region == cldr.RegionUA {
+				return seq.Add(symbols.Symbol_d, '.', symbols.Symbol_MM, '.', year)
+			}
+
 			return seq.Add(symbols.Symbol_dd, '.', symbols.Symbol_MM, '.', year)
 		}
 

--- a/internal/cldr/locale.go
+++ b/internal/cldr/locale.go
@@ -384,6 +384,7 @@ var (
 	RegionTT  = language.MustParseRegion("TT")
 	RegionTV  = language.MustParseRegion("TV")
 	RegionTZ  = language.MustParseRegion("TZ")
+	RegionUA  = language.MustParseRegion("UA")
 	RegionUG  = language.MustParseRegion("UG")
 	RegionUM  = language.MustParseRegion("UM")
 	RegionUS  = language.MustParseRegion("US")

--- a/russian_ua_test.go
+++ b/russian_ua_test.go
@@ -32,3 +32,16 @@ func TestDateTimeFormat_RussianUkraineWeekday(t *testing.T) {
 		t.Fatalf("want %q got %q", want, got)
 	}
 }
+
+func TestDateTimeFormat_RussianUkraineYMed(t *testing.T) {
+	t.Parallel()
+
+	date := time.Date(2025, 5, 5, 0, 0, 0, 0, time.UTC)
+	locale := language.MustParse("ru-UA")
+
+	got := NewDateTimeFormatLayout(locale, "yMEd").Format(date)
+	want := "Пн, 5.05.2025"
+	if got != want {
+		t.Fatalf("want %q got %q", want, got)
+	}
+}


### PR DESCRIPTION
## Summary
- add region UA constant and special case to output single-digit day for ru-UA
- cover ru-UA yMEd skeleton with a regression test

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6894c215a81c832fbc1e7ebc42a386a0