### PR TITLE
Fix ru-UA numeric date day padding

### DIFF
--- a/fmt_ymd.go
+++ b/fmt_ymd.go
@@ -413,10 +413,6 @@ func seqYearMonthDay(locale language.Tag, opts Options) *symbols.Seq {
 		return seq.Add(day, '.', month, '.', year)
 	case cldr.RU:
 		if opts.Month.numeric() && opts.Day.numeric() {
-			if region == cldr.RegionUA {
-				return seq.Add(symbols.Symbol_d, '.', symbols.Symbol_MM, '.', year)
-			}
-
 			return seq.Add(symbols.Symbol_dd, '.', symbols.Symbol_MM, '.', year)
 		}
 

--- a/fmt_ymde.go
+++ b/fmt_ymde.go
@@ -1,12 +1,21 @@
 package intl
 
 import (
+	"github.com/boltegg/intl/internal/cldr"
 	"github.com/boltegg/intl/internal/symbols"
 	"golang.org/x/text/language"
 )
 
 // seqWeekdayYearMonthDay formats a full date with a leading weekday.
 func seqWeekdayYearMonthDay(locale language.Tag, opts Options) *symbols.Seq {
+	lang, _, region := locale.Raw()
+
+	if lang == cldr.RU && region == cldr.RegionUA && opts.Month.numeric() && opts.Day.numeric() {
+		return symbols.NewSeq(locale).
+			Add(opts.Weekday.symbol(), symbols.TxtComma, symbols.TxtSpace,
+				symbols.Symbol_d, '.', symbols.Symbol_MM, '.', opts.Year.symbol())
+	}
+
 	seq := symbols.NewSeq(locale)
 	seq.Add(opts.Weekday.symbol(), symbols.TxtComma, symbols.TxtSpace)
 	seq.AddSeq(seqYearMonthDay(locale, opts))

--- a/russian_ua_test.go
+++ b/russian_ua_test.go
@@ -45,3 +45,16 @@ func TestDateTimeFormat_RussianUkraineYMed(t *testing.T) {
 		t.Fatalf("want %q got %q", want, got)
 	}
 }
+
+func TestDateTimeFormat_RussianUkraineYMd(t *testing.T) {
+	t.Parallel()
+
+	date := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	locale := language.MustParse("ru-UA")
+
+	got := NewDateTimeFormatLayout(locale, "yMd").Format(date)
+	want := "01.01.2025"
+	if got != want {
+		t.Fatalf("want %q got %q", want, got)
+	}
+}


### PR DESCRIPTION
## Summary
- ensure Russian (Ukraine) numeric dates use two-digit day
- keep weekday formats unpadded and add regression test

## Testing
- `go test ./... -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6894c4a1a5d4832f9e835e0819ba9d8e