### PR TITLE
Fix English (Colombia) yMd date order

### DIFF
--- a/english_colombia_test.go
+++ b/english_colombia_test.go
@@ -1,0 +1,21 @@
+package intl
+
+import (
+	"testing"
+	"time"
+
+	"golang.org/x/text/language"
+)
+
+func TestDateTimeFormat_EnglishColombiaYMd(t *testing.T) {
+	t.Parallel()
+
+	date := time.Date(2025, 11, 17, 0, 0, 0, 0, time.UTC)
+	locale := language.MustParse("en-CO")
+
+	got := NewDateTimeFormatLayout(locale, "yMd").Format(date)
+	want := "17/11/2025"
+	if got != want {
+		t.Fatalf("want %q got %q", want, got)
+	}
+}

--- a/fmt_ymd.go
+++ b/fmt_ymd.go
@@ -220,7 +220,7 @@ func seqYearMonthDay(locale language.Tag, opts Options) *symbols.Seq {
 			}
 
 			return seq.Add(day, '/', month, '/', year)
-		case cldr.RegionBE, cldr.RegionHK, cldr.RegionIE, cldr.RegionIN, cldr.RegionZW:
+		case cldr.RegionBE, cldr.RegionCO, cldr.RegionHK, cldr.RegionIE, cldr.RegionIN, cldr.RegionZW:
 			// year=numeric,month=numeric,day=numeric,out=2/1/2024
 			// year=numeric,month=numeric,day=2-digit,out=02/1/2024
 			// year=numeric,month=2-digit,day=numeric,out=2/01/2024


### PR DESCRIPTION
## Summary
- handle yMd formatting for en-CO using day/month/year order
- add regression test for English (Colombia) date formatting

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6894c7a422e0832f968d0d3db7386305