### PR TITLE
Fix month formatting for English Colombia

### DIFF
--- a/fmt_ymd.go
+++ b/fmt_ymd.go
@@ -229,7 +229,11 @@ func seqYearMonthDay(locale language.Tag, opts Options) *symbols.Seq {
 			// year=2-digit,month=numeric,day=2-digit,out=02/1/24
 			// year=2-digit,month=2-digit,day=numeric,out=2/01/24
 			// year=2-digit,month=2-digit,day=2-digit,out=02/01/24
-			return seq.Add(day, '/', month, '/', year)
+			if opts.Month.numeric() || opts.Month.twoDigit() {
+				return seq.Add(day, '/', month, '/', year)
+			}
+
+			return seq.Add(day, symbols.TxtSpace, month, symbols.TxtSpace, year)
 		case cldr.RegionBW, cldr.RegionBZ:
 			// year=numeric,month=numeric,day=numeric,out=02/01/2024
 			// year=numeric,month=numeric,day=2-digit,out=02/01/2024

--- a/internal/cldr/cldr.go
+++ b/internal/cldr/cldr.go
@@ -3,14 +3,20 @@ package cldr
 import "golang.org/x/text/language"
 
 func MonthNames(locale string, context, width string) CalendarMonths {
-	indexes := MonthLookup[locale]
+	tag := language.Make(locale)
+
+	indexes, ok := MonthLookup[locale]
+	if !ok {
+		base, _ := tag.Base()
+		indexes = MonthLookup[base.String()]
+	}
 
 	// Russian locales mix abbreviated and wide month names when formatting
 	// dates with the abbreviated width. The base data uses the abbreviated
 	// set, but certain months (March, May, June, July) should use the wide
 	// genitive forms. Adjust the result accordingly.
 	if width == "abbreviated" && context == "format" {
-		if base, _ := language.Make(locale).Base(); base.String() == "ru" {
+		if base, _ := tag.Base(); base.String() == "ru" {
 			var out CalendarMonths
 			if v := int(indexes[0]); v > 0 && v < len(CalendarMonthNames) {
 				out = CalendarMonthNames[v]


### PR DESCRIPTION
## Summary
- ensure month names fall back to base language when locale-specific data missing
- format day-month-year with spaces for English locales like Colombia when using month names

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6894cb0f829c832f85d4b5b6a361ccb8