### PR TITLE
Fix day padding for English Colombia date layouts

### DIFF
--- a/english_colombia_test.go
+++ b/english_colombia_test.go
@@ -23,11 +23,11 @@ func TestDateTimeFormat_EnglishColombiaYMd(t *testing.T) {
 func TestDateTimeFormat_EnglishColombiaMEd(t *testing.T) {
 	t.Parallel()
 
-	date := time.Date(2025, 6, 14, 0, 0, 0, 0, time.UTC)
+	date := time.Date(2025, 2, 4, 0, 0, 0, 0, time.UTC)
 	locale := language.MustParse("en-CO")
 
 	got := NewDateTimeFormatLayout(locale, "MEd").Format(date)
-	want := "Sat, 14/06"
+	want := "Tue, 4/02"
 	if got != want {
 		t.Fatalf("want %q got %q", want, got)
 	}

--- a/fmt_md.go
+++ b/fmt_md.go
@@ -42,7 +42,7 @@ func seqMonthDay(locale language.Tag, opts Options) *symbols.Seq {
 			}
 
 			if opts.Month.numeric() && opts.Day.numeric() {
-				return seq.Add(symbols.Symbol_dd, '/', symbols.Symbol_MM)
+				return seq.Add(symbols.Symbol_d, '/', symbols.Symbol_MM)
 			}
 
 			return seq.Add(day, symbols.TxtSpace, month)


### PR DESCRIPTION
## Summary
- avoid zero-padding day for English (Colombia) month/day formats
- add regression test for English Colombia MEd layout

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68959b5f0b04832fa429e017ffb67e2e