### PR TITLE
fix en-CO MMMMd month-day order

### DIFF
--- a/english_colombia_test.go
+++ b/english_colombia_test.go
@@ -32,3 +32,16 @@ func TestDateTimeFormat_EnglishColombiaMEd(t *testing.T) {
 		t.Fatalf("want %q got %q", want, got)
 	}
 }
+
+func TestDateTimeFormat_EnglishColombiaMMMMd(t *testing.T) {
+	t.Parallel()
+
+	date := time.Date(2025, 11, 1, 0, 0, 0, 0, time.UTC)
+	locale := language.MustParse("en-CO")
+
+	got := NewDateTimeFormatLayout(locale, "MMMMd").Format(date)
+	want := "November 1"
+	if got != want {
+		t.Fatalf("want %q got %q", want, got)
+	}
+}

--- a/fmt_md.go
+++ b/fmt_md.go
@@ -41,6 +41,10 @@ func seqMonthDay(locale language.Tag, opts Options) *symbols.Seq {
 				return seq.Add(month, '/', day)
 			}
 
+			if region == cldr.RegionCO && opts.Month == MonthLong && opts.Day.numeric() {
+				return seq.Add(month, symbols.TxtSpace, day)
+			}
+
 			if opts.Month.numeric() && opts.Day.numeric() {
 				return seq.Add(symbols.Symbol_d, '/', symbols.Symbol_MM)
 			}


### PR DESCRIPTION
## Summary
- ensure English (Colombia) MMMMd places month before day
- add regression test for en-CO MMMMd formatting

## Testing
- `go test ./...`
- `golangci-lint run ./...` *(fails: copyloopvar, cyclop, gocognit, gofumpt, govet, ireturn, lll, mnd, nestif, paralleltest, unconvert, unused)*

------
https://chatgpt.com/codex/tasks/task_e_68959d4775e8832fb94eefd3ee1b57cd