### PR TITLE
Use day-first long date order for English (Colombia)

### DIFF
--- a/english_colombia_test.go
+++ b/english_colombia_test.go
@@ -40,7 +40,20 @@ func TestDateTimeFormat_EnglishColombiaMMMMd(t *testing.T) {
 	locale := language.MustParse("en-CO")
 
 	got := NewDateTimeFormatLayout(locale, "MMMMd").Format(date)
-	want := "November 1"
+	want := "1 November"
+	if got != want {
+		t.Fatalf("want %q got %q", want, got)
+	}
+}
+
+func TestDateTimeFormat_EnglishColombiaMMMMEEEEd(t *testing.T) {
+	t.Parallel()
+
+	date := time.Date(2025, 4, 3, 0, 0, 0, 0, time.UTC)
+	locale := language.MustParse("en-CO")
+
+	got := NewDateTimeFormatLayout(locale, "MMMMEEEEd").Format(date)
+	want := "Thursday, 3 April"
 	if got != want {
 		t.Fatalf("want %q got %q", want, got)
 	}

--- a/fmt_md.go
+++ b/fmt_md.go
@@ -41,10 +41,6 @@ func seqMonthDay(locale language.Tag, opts Options) *symbols.Seq {
 				return seq.Add(month, '/', day)
 			}
 
-			if region == cldr.RegionCO && opts.Month == MonthLong && opts.Day.numeric() {
-				return seq.Add(month, symbols.TxtSpace, day)
-			}
-
 			if opts.Month.numeric() && opts.Day.numeric() {
 				return seq.Add(symbols.Symbol_d, '/', symbols.Symbol_MM)
 			}


### PR DESCRIPTION
## Summary
- remove month-first special case for English (Colombia) so long month formats use day-first order
- update and extend English (Colombia) tests to cover day-first patterns

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895a1e55b2c832fab395d5becab6f10