### PR TITLE
Pad month for English (Colombia) yMd format

### DIFF
--- a/english_colombia_test.go
+++ b/english_colombia_test.go
@@ -20,6 +20,19 @@ func TestDateTimeFormat_EnglishColombiaYMd(t *testing.T) {
 	}
 }
 
+func TestDateTimeFormat_EnglishColombiaYMdSeptember(t *testing.T) {
+	t.Parallel()
+
+	date := time.Date(2025, 9, 5, 0, 0, 0, 0, time.UTC)
+	locale := language.MustParse("en-CO")
+
+	got := NewDateTimeFormatLayout(locale, "yMd").Format(date)
+	want := "5/09/2025"
+	if got != want {
+		t.Fatalf("want %q got %q", want, got)
+	}
+}
+
 func TestDateTimeFormat_EnglishColombiaMEd(t *testing.T) {
 	t.Parallel()
 

--- a/fmt_ymd.go
+++ b/fmt_ymd.go
@@ -229,6 +229,10 @@ func seqYearMonthDay(locale language.Tag, opts Options) *symbols.Seq {
 			// year=2-digit,month=numeric,day=2-digit,out=02/1/24
 			// year=2-digit,month=2-digit,day=numeric,out=2/01/24
 			// year=2-digit,month=2-digit,day=2-digit,out=02/01/24
+			if opts.Month.numeric() && opts.Day.numeric() {
+				return seq.Add(day, '/', symbols.Symbol_MM, '/', year)
+			}
+
 			if opts.Month.numeric() || opts.Month.twoDigit() {
 				return seq.Add(day, '/', month, '/', year)
 			}


### PR DESCRIPTION
## Summary
- ensure yMd formats for English (Colombia) pad month with two digits
- add regression test for September date

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895a3a421c0832f9f99d8d23d6621d0