### PR TITLE
fix en-CO date ordering

### DIFF
--- a/english_colombia_test.go
+++ b/english_colombia_test.go
@@ -14,7 +14,7 @@ func TestDateTimeFormat_EnglishColombiaYMd(t *testing.T) {
 	locale := language.MustParse("en-CO")
 
 	got := NewDateTimeFormatLayout(locale, "yMd").Format(date)
-	want := "17/11/2025"
+	want := "11/17/2025"
 	if got != want {
 		t.Fatalf("want %q got %q", want, got)
 	}
@@ -27,7 +27,7 @@ func TestDateTimeFormat_EnglishColombiaYMdSeptember(t *testing.T) {
 	locale := language.MustParse("en-CO")
 
 	got := NewDateTimeFormatLayout(locale, "yMd").Format(date)
-	want := "5/09/2025"
+	want := "9/5/2025"
 	if got != want {
 		t.Fatalf("want %q got %q", want, got)
 	}
@@ -40,7 +40,7 @@ func TestDateTimeFormat_EnglishColombiaMEd(t *testing.T) {
 	locale := language.MustParse("en-CO")
 
 	got := NewDateTimeFormatLayout(locale, "MEd").Format(date)
-	want := "Tue, 4/02"
+	want := "Tue, 2/4"
 	if got != want {
 		t.Fatalf("want %q got %q", want, got)
 	}
@@ -53,7 +53,7 @@ func TestDateTimeFormat_EnglishColombiaMMMMd(t *testing.T) {
 	locale := language.MustParse("en-CO")
 
 	got := NewDateTimeFormatLayout(locale, "MMMMd").Format(date)
-	want := "1 November"
+	want := "November 1"
 	if got != want {
 		t.Fatalf("want %q got %q", want, got)
 	}
@@ -66,7 +66,7 @@ func TestDateTimeFormat_EnglishColombiaMMMMEEEEd(t *testing.T) {
 	locale := language.MustParse("en-CO")
 
 	got := NewDateTimeFormatLayout(locale, "MMMMEEEEd").Format(date)
-	want := "Thursday, 3 April"
+	want := "Thursday, April 3"
 	if got != want {
 		t.Fatalf("want %q got %q", want, got)
 	}

--- a/fmt_md.go
+++ b/fmt_md.go
@@ -26,7 +26,7 @@ func seqMonthDay(locale language.Tag, opts Options) *symbols.Seq {
 			return seq.Add(month, symbols.TxtSpace, day)
 		case cldr.Region001, cldr.Region150, cldr.RegionAE, cldr.RegionAG, cldr.RegionAI, cldr.RegionAT, cldr.RegionBB,
 			cldr.RegionBM, cldr.RegionBS, cldr.RegionBW, cldr.RegionBZ, cldr.RegionCC, cldr.RegionCK, cldr.RegionCM,
-			cldr.RegionCO, cldr.RegionCX, cldr.RegionCY, cldr.RegionDE, cldr.RegionDG, cldr.RegionDK, cldr.RegionDM,
+			cldr.RegionCX, cldr.RegionCY, cldr.RegionDE, cldr.RegionDG, cldr.RegionDK, cldr.RegionDM,
 			cldr.RegionER, cldr.RegionFI, cldr.RegionFJ, cldr.RegionFK, cldr.RegionFM, cldr.RegionGB, cldr.RegionGD,
 			cldr.RegionGG, cldr.RegionGH, cldr.RegionGI, cldr.RegionGM, cldr.RegionGY, cldr.RegionHK, cldr.RegionID,
 			cldr.RegionIL, cldr.RegionIM, cldr.RegionIN, cldr.RegionIO, cldr.RegionJE, cldr.RegionJM, cldr.RegionKE,

--- a/fmt_ymd.go
+++ b/fmt_ymd.go
@@ -220,7 +220,7 @@ func seqYearMonthDay(locale language.Tag, opts Options) *symbols.Seq {
 			}
 
 			return seq.Add(day, '/', month, '/', year)
-		case cldr.RegionBE, cldr.RegionCO, cldr.RegionHK, cldr.RegionIE, cldr.RegionIN, cldr.RegionZW:
+		case cldr.RegionBE, cldr.RegionHK, cldr.RegionIE, cldr.RegionIN, cldr.RegionZW:
 			// year=numeric,month=numeric,day=numeric,out=2/1/2024
 			// year=numeric,month=numeric,day=2-digit,out=02/1/2024
 			// year=numeric,month=2-digit,day=numeric,out=2/01/2024


### PR DESCRIPTION
## Summary
- remove en-CO from day-first region list
- align English (Colombia) tests with month-first pattern

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895aaef17e0832fb096fbeef91bec6e