### PR TITLE
Fix MMMMd month/day order for en-CO

### DIFF
--- a/english_colombia_test.go
+++ b/english_colombia_test.go
@@ -52,11 +52,11 @@ func TestDateTimeFormat_EnglishColombiaMMMMd(t *testing.T) {
 	date := time.Date(2025, 11, 1, 0, 0, 0, 0, time.UTC)
 	locale := language.MustParse("en-CO")
 
-	got := NewDateTimeFormatLayout(locale, "MMMMd").Format(date)
-	want := "1 November"
-	if got != want {
-		t.Fatalf("want %q got %q", want, got)
-	}
+        got := NewDateTimeFormatLayout(locale, "MMMMd").Format(date)
+        want := "November 1"
+        if got != want {
+                t.Fatalf("want %q got %q", want, got)
+        }
 }
 
 func TestDateTimeFormat_EnglishColombiaMMMMEEEEd(t *testing.T) {

--- a/fmt_md.go
+++ b/fmt_md.go
@@ -24,19 +24,19 @@ func seqMonthDay(locale language.Tag, opts Options) *symbols.Seq {
 			}
 
 			return seq.Add(month, symbols.TxtSpace, day)
-		case cldr.Region001, cldr.Region150, cldr.RegionAE, cldr.RegionAG, cldr.RegionAI, cldr.RegionAT, cldr.RegionBB,
-			cldr.RegionBM, cldr.RegionBS, cldr.RegionBW, cldr.RegionBZ, cldr.RegionCC, cldr.RegionCK, cldr.RegionCM,
-			cldr.RegionCO, cldr.RegionCX, cldr.RegionCY, cldr.RegionDE, cldr.RegionDG, cldr.RegionDK, cldr.RegionDM,
-			cldr.RegionER, cldr.RegionFI, cldr.RegionFJ, cldr.RegionFK, cldr.RegionFM, cldr.RegionGB, cldr.RegionGD,
-			cldr.RegionGG, cldr.RegionGH, cldr.RegionGI, cldr.RegionGM, cldr.RegionGY, cldr.RegionHK, cldr.RegionID,
-			cldr.RegionIL, cldr.RegionIM, cldr.RegionIN, cldr.RegionIO, cldr.RegionJE, cldr.RegionJM, cldr.RegionKE,
-			cldr.RegionKI, cldr.RegionKN, cldr.RegionKY, cldr.RegionLC, cldr.RegionLR, cldr.RegionLS, cldr.RegionMG,
-			cldr.RegionMO, cldr.RegionMS, cldr.RegionMT, cldr.RegionMU, cldr.RegionMV, cldr.RegionMW, cldr.RegionMY,
-			cldr.RegionNA, cldr.RegionNF, cldr.RegionNG, cldr.RegionNL, cldr.RegionNR, cldr.RegionNU, cldr.RegionPG,
-			cldr.RegionPK, cldr.RegionPN, cldr.RegionPW, cldr.RegionRW, cldr.RegionSB, cldr.RegionSC, cldr.RegionSD,
-			cldr.RegionSE, cldr.RegionSG, cldr.RegionSH, cldr.RegionSI, cldr.RegionSL, cldr.RegionSS, cldr.RegionSX,
-			cldr.RegionSZ, cldr.RegionTC, cldr.RegionTK, cldr.RegionTO, cldr.RegionTT, cldr.RegionTV, cldr.RegionTZ,
-			cldr.RegionUG, cldr.RegionVC, cldr.RegionVG, cldr.RegionVU, cldr.RegionWS, cldr.RegionZM:
+               case cldr.Region001, cldr.Region150, cldr.RegionAE, cldr.RegionAG, cldr.RegionAI, cldr.RegionAT, cldr.RegionBB,
+                       cldr.RegionBM, cldr.RegionBS, cldr.RegionBW, cldr.RegionBZ, cldr.RegionCC, cldr.RegionCK, cldr.RegionCM,
+                       cldr.RegionCX, cldr.RegionCY, cldr.RegionDE, cldr.RegionDG, cldr.RegionDK, cldr.RegionDM,
+                       cldr.RegionER, cldr.RegionFI, cldr.RegionFJ, cldr.RegionFK, cldr.RegionFM, cldr.RegionGB, cldr.RegionGD,
+                       cldr.RegionGG, cldr.RegionGH, cldr.RegionGI, cldr.RegionGM, cldr.RegionGY, cldr.RegionHK, cldr.RegionID,
+                       cldr.RegionIL, cldr.RegionIM, cldr.RegionIN, cldr.RegionIO, cldr.RegionJE, cldr.RegionJM, cldr.RegionKE,
+                       cldr.RegionKI, cldr.RegionKN, cldr.RegionKY, cldr.RegionLC, cldr.RegionLR, cldr.RegionLS, cldr.RegionMG,
+                       cldr.RegionMO, cldr.RegionMS, cldr.RegionMT, cldr.RegionMU, cldr.RegionMV, cldr.RegionMW, cldr.RegionMY,
+                       cldr.RegionNA, cldr.RegionNF, cldr.RegionNG, cldr.RegionNL, cldr.RegionNR, cldr.RegionNU, cldr.RegionPG,
+                       cldr.RegionPK, cldr.RegionPN, cldr.RegionPW, cldr.RegionRW, cldr.RegionSB, cldr.RegionSC, cldr.RegionSD,
+                       cldr.RegionSE, cldr.RegionSG, cldr.RegionSH, cldr.RegionSI, cldr.RegionSL, cldr.RegionSS, cldr.RegionSX,
+                       cldr.RegionSZ, cldr.RegionTC, cldr.RegionTK, cldr.RegionTO, cldr.RegionTT, cldr.RegionTV, cldr.RegionTZ,
+                       cldr.RegionUG, cldr.RegionVC, cldr.RegionVG, cldr.RegionVU, cldr.RegionWS, cldr.RegionZM:
 			if script == cldr.Shaw {
 				return seq.Add(month, '/', day)
 			}
@@ -45,7 +45,16 @@ func seqMonthDay(locale language.Tag, opts Options) *symbols.Seq {
 				return seq.Add(symbols.Symbol_d, '/', symbols.Symbol_MM)
 			}
 
-			return seq.Add(day, symbols.TxtSpace, month)
+                       return seq.Add(day, symbols.TxtSpace, month)
+               case cldr.RegionCO:
+                       if opts.Month == MonthLong && opts.Day.numeric() && opts.Weekday.und() {
+                               return seq.Add(month, symbols.TxtSpace, day)
+                       }
+                       if opts.Month.numeric() && opts.Day.numeric() {
+                               return seq.Add(symbols.Symbol_d, '/', symbols.Symbol_MM)
+                       }
+
+                       return seq.Add(day, symbols.TxtSpace, month)
 		case cldr.RegionAU, cldr.RegionBE, cldr.RegionIE, cldr.RegionNZ, cldr.RegionZW:
 			if opts.Month.numeric() || opts.Month.twoDigit() {
 				return seq.Add(day, '/', month)


### PR DESCRIPTION
## Summary
- Ensure English (Colombia) MMMMd format uses month-before-day when no weekday is specified
- Update English Colombia tests for new MMMMd output

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895ad376a7c832f9cb79c14e43aea82