### PR TITLE
Pad month for en-CO yM formatting

### DIFF
--- a/fmt_ym.go
+++ b/fmt_ym.go
@@ -26,7 +26,7 @@ func seqYearMonth(locale language.Tag, opts Options) *symbols.Seq {
 			return seq.Add(month, ' ', year)
 		case cldr.Region001, cldr.Region150, cldr.RegionAE, cldr.RegionAG, cldr.RegionAI, cldr.RegionAT, cldr.RegionAU,
 			cldr.RegionBB, cldr.RegionBE, cldr.RegionBM, cldr.RegionBS, cldr.RegionBW, cldr.RegionBZ, cldr.RegionCC,
-			cldr.RegionCK, cldr.RegionCM, cldr.RegionCX, cldr.RegionCY, cldr.RegionDE, cldr.RegionDG, cldr.RegionDK,
+			cldr.RegionCK, cldr.RegionCM, cldr.RegionCO, cldr.RegionCX, cldr.RegionCY, cldr.RegionDE, cldr.RegionDG, cldr.RegionDK,
 			cldr.RegionDM, cldr.RegionER, cldr.RegionFI, cldr.RegionFJ, cldr.RegionFK, cldr.RegionFM, cldr.RegionGB,
 			cldr.RegionGD, cldr.RegionGG, cldr.RegionGH, cldr.RegionGI, cldr.RegionGM, cldr.RegionGY, cldr.RegionHK,
 			cldr.RegionID, cldr.RegionIE, cldr.RegionIL, cldr.RegionIM, cldr.RegionIN, cldr.RegionIO, cldr.RegionJE,


### PR DESCRIPTION
## Summary
- pad month with leading zero for English (Colombia) yM format

## Testing
- `go test ./...`
- `go run /tmp/ym.go`


------
https://chatgpt.com/codex/tasks/task_e_6895af265c60832fa61f6d41d75f69cf