### PR TITLE
Fix English Ukraine yMd date format

### DIFF
--- a/english_ukraine_test.go
+++ b/english_ukraine_test.go
@@ -1,0 +1,21 @@
+package intl
+
+import (
+	"testing"
+	"time"
+
+	"golang.org/x/text/language"
+)
+
+func TestDateTimeFormat_EnglishUkraineYMd(t *testing.T) {
+	t.Parallel()
+
+	date := time.Date(2025, 12, 31, 0, 0, 0, 0, time.UTC)
+	locale := language.MustParse("en-UA")
+
+	got := NewDateTimeFormatLayout(locale, "yMd").Format(date)
+	want := "31/12/2025"
+	if got != want {
+		t.Fatalf("want %q got %q", want, got)
+	}
+}

--- a/fmt_ymd.go
+++ b/fmt_ymd.go
@@ -187,7 +187,7 @@ func seqYearMonthDay(locale language.Tag, opts Options) *symbols.Seq {
 			cldr.RegionMY, cldr.RegionNA, cldr.RegionNF, cldr.RegionNG, cldr.RegionNL, cldr.RegionNR, cldr.RegionNU,
 			cldr.RegionPG, cldr.RegionPK, cldr.RegionPN, cldr.RegionPW, cldr.RegionRW, cldr.RegionSB, cldr.RegionSC,
 			cldr.RegionSD, cldr.RegionSH, cldr.RegionSI, cldr.RegionSL, cldr.RegionSS, cldr.RegionSX, cldr.RegionSZ,
-			cldr.RegionTC, cldr.RegionTK, cldr.RegionTO, cldr.RegionTT, cldr.RegionTV, cldr.RegionTZ, cldr.RegionUG,
+			cldr.RegionTC, cldr.RegionTK, cldr.RegionTO, cldr.RegionTT, cldr.RegionTV, cldr.RegionTZ, cldr.RegionUA, cldr.RegionUG,
 			cldr.RegionVC, cldr.RegionVG, cldr.RegionVU, cldr.RegionWS, cldr.RegionZM:
 			// year=numeric,month=numeric,day=numeric,out=02/01/2024
 			// year=numeric,month=numeric,day=2-digit,out=02/1/2024


### PR DESCRIPTION
## Summary
- ensure English (Ukraine) uses day-month-year order for yMd format
- add test to verify English (Ukraine) date output

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895b1640684832f865018b890d4486e