### PR TITLE
Fix en-UA yMd formatting

### DIFF
--- a/english_ukraine_test.go
+++ b/english_ukraine_test.go
@@ -19,3 +19,16 @@ func TestDateTimeFormat_EnglishUkraineYMd(t *testing.T) {
 		t.Fatalf("want %q got %q", want, got)
 	}
 }
+
+func TestDateTimeFormat_EnglishUkraineYMd_NoPadding(t *testing.T) {
+	t.Parallel()
+
+	date := time.Date(2025, time.October, 6, 0, 0, 0, 0, time.UTC)
+	locale := language.MustParse("en-UA")
+
+	got := NewDateTimeFormatLayout(locale, "yMd").Format(date)
+	want := "6/10/2025"
+	if got != want {
+		t.Fatalf("want %q got %q", want, got)
+	}
+}

--- a/fmt_ymd.go
+++ b/fmt_ymd.go
@@ -187,7 +187,7 @@ func seqYearMonthDay(locale language.Tag, opts Options) *symbols.Seq {
 			cldr.RegionMY, cldr.RegionNA, cldr.RegionNF, cldr.RegionNG, cldr.RegionNL, cldr.RegionNR, cldr.RegionNU,
 			cldr.RegionPG, cldr.RegionPK, cldr.RegionPN, cldr.RegionPW, cldr.RegionRW, cldr.RegionSB, cldr.RegionSC,
 			cldr.RegionSD, cldr.RegionSH, cldr.RegionSI, cldr.RegionSL, cldr.RegionSS, cldr.RegionSX, cldr.RegionSZ,
-			cldr.RegionTC, cldr.RegionTK, cldr.RegionTO, cldr.RegionTT, cldr.RegionTV, cldr.RegionTZ, cldr.RegionUA, cldr.RegionUG,
+			cldr.RegionTC, cldr.RegionTK, cldr.RegionTO, cldr.RegionTT, cldr.RegionTV, cldr.RegionTZ, cldr.RegionUG,
 			cldr.RegionVC, cldr.RegionVG, cldr.RegionVU, cldr.RegionWS, cldr.RegionZM:
 			// year=numeric,month=numeric,day=numeric,out=02/01/2024
 			// year=numeric,month=numeric,day=2-digit,out=02/1/2024
@@ -203,6 +203,12 @@ func seqYearMonthDay(locale language.Tag, opts Options) *symbols.Seq {
 
 			if opts.Month.numeric() && opts.Day.numeric() {
 				return seq.Add(symbols.Symbol_dd, '/', symbols.Symbol_MM, '/', year)
+			}
+
+			return seq.Add(day, symbols.TxtSpace, month, symbols.TxtSpace, year)
+		case cldr.RegionUA:
+			if opts.Month.numeric() && opts.Day.numeric() {
+				return seq.Add(day, '/', month, '/', year)
 			}
 
 			return seq.Add(day, symbols.TxtSpace, month, symbols.TxtSpace, year)


### PR DESCRIPTION
## Summary
- special-case en-UA yMd to avoid zero padding on day/month
- cover en-UA yMd formatting with a regression test

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895b33857cc832fb8721241884d6a90