### PR TITLE
Fix en-UA yMEd weekday comma

### DIFF
--- a/english_ukraine_test.go
+++ b/english_ukraine_test.go
@@ -20,6 +20,19 @@ func TestDateTimeFormat_EnglishUkraineYMd(t *testing.T) {
 	}
 }
 
+func TestDateTimeFormat_EnglishUkraineYMed(t *testing.T) {
+	t.Parallel()
+
+	date := time.Date(2025, 4, 1, 0, 0, 0, 0, time.UTC)
+	locale := language.MustParse("en-UA")
+
+	got := NewDateTimeFormatLayout(locale, "yMEd").Format(date)
+	want := "Tue 1/4/2025"
+	if got != want {
+		t.Fatalf("want %q got %q", want, got)
+	}
+}
+
 func TestDateTimeFormat_EnglishUkraineYMd_NoPadding(t *testing.T) {
 	t.Parallel()
 

--- a/fmt_med.go
+++ b/fmt_med.go
@@ -1,11 +1,20 @@
 package intl
 
 import (
+	"github.com/boltegg/intl/internal/cldr"
 	"github.com/boltegg/intl/internal/symbols"
 	"golang.org/x/text/language"
 )
 
 func seqWeekdayMonthDay(locale language.Tag, opts Options) *symbols.Seq {
+	lang, _, region := locale.Raw()
+
+	if lang == cldr.EN && region == cldr.RegionUA {
+		return symbols.NewSeq(locale).
+			Add(opts.Weekday.symbol(), symbols.TxtSpace).
+			AddSeq(seqMonthDay(locale, opts))
+	}
+
 	seq := symbols.NewSeq(locale)
 	seq.Add(opts.Weekday.symbol(), symbols.TxtComma, symbols.TxtSpace)
 	seq.AddSeq(seqMonthDay(locale, opts))

--- a/fmt_ymde.go
+++ b/fmt_ymde.go
@@ -10,6 +10,12 @@ import (
 func seqWeekdayYearMonthDay(locale language.Tag, opts Options) *symbols.Seq {
 	lang, _, region := locale.Raw()
 
+	if lang == cldr.EN && region == cldr.RegionUA {
+		return symbols.NewSeq(locale).
+			Add(opts.Weekday.symbol(), symbols.TxtSpace).
+			AddSeq(seqYearMonthDay(locale, opts))
+	}
+
 	if lang == cldr.RU && region == cldr.RegionUA && opts.Month.numeric() && opts.Day.numeric() {
 		return symbols.NewSeq(locale).
 			Add(opts.Weekday.symbol(), symbols.TxtComma, symbols.TxtSpace,


### PR DESCRIPTION
## Summary
- ensure English (Ukraine) yMEd and MEd layouts omit the comma after weekday
- add regression test for en-UA yMEd

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895b59c349c832fb6e63c14244cc94b