### PR TITLE
Fix English Ukraine MMMMEEEEd date format

### DIFF
--- a/english_ukraine_test.go
+++ b/english_ukraine_test.go
@@ -45,3 +45,16 @@ func TestDateTimeFormat_EnglishUkraineYMd_NoPadding(t *testing.T) {
 		t.Fatalf("want %q got %q", want, got)
 	}
 }
+
+func TestDateTimeFormat_EnglishUkraineMMMMEEEEd(t *testing.T) {
+	t.Parallel()
+
+	date := time.Date(2014, time.November, 30, 0, 0, 0, 0, time.UTC)
+	locale := language.MustParse("en-UA")
+
+	got := NewDateTimeFormatLayout(locale, "MMMMEEEEd").Format(date)
+	want := "Sunday, 30 November"
+	if got != want {
+		t.Fatalf("want %q got %q", want, got)
+	}
+}

--- a/fmt_md.go
+++ b/fmt_md.go
@@ -24,19 +24,19 @@ func seqMonthDay(locale language.Tag, opts Options) *symbols.Seq {
 			}
 
 			return seq.Add(month, symbols.TxtSpace, day)
-               case cldr.Region001, cldr.Region150, cldr.RegionAE, cldr.RegionAG, cldr.RegionAI, cldr.RegionAT, cldr.RegionBB,
-                       cldr.RegionBM, cldr.RegionBS, cldr.RegionBW, cldr.RegionBZ, cldr.RegionCC, cldr.RegionCK, cldr.RegionCM,
-                       cldr.RegionCX, cldr.RegionCY, cldr.RegionDE, cldr.RegionDG, cldr.RegionDK, cldr.RegionDM,
-                       cldr.RegionER, cldr.RegionFI, cldr.RegionFJ, cldr.RegionFK, cldr.RegionFM, cldr.RegionGB, cldr.RegionGD,
-                       cldr.RegionGG, cldr.RegionGH, cldr.RegionGI, cldr.RegionGM, cldr.RegionGY, cldr.RegionHK, cldr.RegionID,
-                       cldr.RegionIL, cldr.RegionIM, cldr.RegionIN, cldr.RegionIO, cldr.RegionJE, cldr.RegionJM, cldr.RegionKE,
-                       cldr.RegionKI, cldr.RegionKN, cldr.RegionKY, cldr.RegionLC, cldr.RegionLR, cldr.RegionLS, cldr.RegionMG,
-                       cldr.RegionMO, cldr.RegionMS, cldr.RegionMT, cldr.RegionMU, cldr.RegionMV, cldr.RegionMW, cldr.RegionMY,
-                       cldr.RegionNA, cldr.RegionNF, cldr.RegionNG, cldr.RegionNL, cldr.RegionNR, cldr.RegionNU, cldr.RegionPG,
-                       cldr.RegionPK, cldr.RegionPN, cldr.RegionPW, cldr.RegionRW, cldr.RegionSB, cldr.RegionSC, cldr.RegionSD,
-                       cldr.RegionSE, cldr.RegionSG, cldr.RegionSH, cldr.RegionSI, cldr.RegionSL, cldr.RegionSS, cldr.RegionSX,
-                       cldr.RegionSZ, cldr.RegionTC, cldr.RegionTK, cldr.RegionTO, cldr.RegionTT, cldr.RegionTV, cldr.RegionTZ,
-                       cldr.RegionUG, cldr.RegionVC, cldr.RegionVG, cldr.RegionVU, cldr.RegionWS, cldr.RegionZM:
+		case cldr.Region001, cldr.Region150, cldr.RegionAE, cldr.RegionAG, cldr.RegionAI, cldr.RegionAT, cldr.RegionBB,
+			cldr.RegionBM, cldr.RegionBS, cldr.RegionBW, cldr.RegionBZ, cldr.RegionCC, cldr.RegionCK, cldr.RegionCM,
+			cldr.RegionCX, cldr.RegionCY, cldr.RegionDE, cldr.RegionDG, cldr.RegionDK, cldr.RegionDM,
+			cldr.RegionER, cldr.RegionFI, cldr.RegionFJ, cldr.RegionFK, cldr.RegionFM, cldr.RegionGB, cldr.RegionGD,
+			cldr.RegionGG, cldr.RegionGH, cldr.RegionGI, cldr.RegionGM, cldr.RegionGY, cldr.RegionHK, cldr.RegionID,
+			cldr.RegionIL, cldr.RegionIM, cldr.RegionIN, cldr.RegionIO, cldr.RegionJE, cldr.RegionJM, cldr.RegionKE,
+			cldr.RegionKI, cldr.RegionKN, cldr.RegionKY, cldr.RegionLC, cldr.RegionLR, cldr.RegionLS, cldr.RegionMG,
+			cldr.RegionMO, cldr.RegionMS, cldr.RegionMT, cldr.RegionMU, cldr.RegionMV, cldr.RegionMW, cldr.RegionMY,
+			cldr.RegionNA, cldr.RegionNF, cldr.RegionNG, cldr.RegionNL, cldr.RegionNR, cldr.RegionNU, cldr.RegionPG,
+			cldr.RegionPK, cldr.RegionPN, cldr.RegionPW, cldr.RegionRW, cldr.RegionSB, cldr.RegionSC, cldr.RegionSD,
+			cldr.RegionSE, cldr.RegionSG, cldr.RegionSH, cldr.RegionSI, cldr.RegionSL, cldr.RegionSS, cldr.RegionSX,
+			cldr.RegionSZ, cldr.RegionTC, cldr.RegionTK, cldr.RegionTO, cldr.RegionTT, cldr.RegionTV, cldr.RegionTZ,
+			cldr.RegionUG, cldr.RegionVC, cldr.RegionVG, cldr.RegionVU, cldr.RegionWS, cldr.RegionZM:
 			if script == cldr.Shaw {
 				return seq.Add(month, '/', day)
 			}
@@ -45,16 +45,16 @@ func seqMonthDay(locale language.Tag, opts Options) *symbols.Seq {
 				return seq.Add(symbols.Symbol_d, '/', symbols.Symbol_MM)
 			}
 
-                       return seq.Add(day, symbols.TxtSpace, month)
-               case cldr.RegionCO:
-                       if opts.Month == MonthLong && opts.Day.numeric() && opts.Weekday.und() {
-                               return seq.Add(month, symbols.TxtSpace, day)
-                       }
-                       if opts.Month.numeric() && opts.Day.numeric() {
-                               return seq.Add(symbols.Symbol_d, '/', symbols.Symbol_MM)
-                       }
+			return seq.Add(day, symbols.TxtSpace, month)
+		case cldr.RegionCO:
+			if opts.Month == MonthLong && opts.Day.numeric() && opts.Weekday.und() {
+				return seq.Add(month, symbols.TxtSpace, day)
+			}
+			if opts.Month.numeric() && opts.Day.numeric() {
+				return seq.Add(symbols.Symbol_d, '/', symbols.Symbol_MM)
+			}
 
-                       return seq.Add(day, symbols.TxtSpace, month)
+			return seq.Add(day, symbols.TxtSpace, month)
 		case cldr.RegionAU, cldr.RegionBE, cldr.RegionIE, cldr.RegionNZ, cldr.RegionZW:
 			if opts.Month.numeric() || opts.Month.twoDigit() {
 				return seq.Add(day, '/', month)
@@ -70,6 +70,12 @@ func seqMonthDay(locale language.Tag, opts Options) *symbols.Seq {
 		case cldr.RegionCH:
 			if opts.Month.numeric() && opts.Day.numeric() {
 				return seq.Add(symbols.Symbol_dd, '.', symbols.Symbol_MM)
+			}
+
+			return seq.Add(day, symbols.TxtSpace, month)
+		case cldr.RegionUA:
+			if opts.Month.numeric() && opts.Day.numeric() {
+				return seq.Add(day, '/', month)
 			}
 
 			return seq.Add(day, symbols.TxtSpace, month)

--- a/fmt_med.go
+++ b/fmt_med.go
@@ -1,20 +1,11 @@
 package intl
 
 import (
-	"github.com/boltegg/intl/internal/cldr"
 	"github.com/boltegg/intl/internal/symbols"
 	"golang.org/x/text/language"
 )
 
 func seqWeekdayMonthDay(locale language.Tag, opts Options) *symbols.Seq {
-	lang, _, region := locale.Raw()
-
-	if lang == cldr.EN && region == cldr.RegionUA {
-		return symbols.NewSeq(locale).
-			Add(opts.Weekday.symbol(), symbols.TxtSpace).
-			AddSeq(seqMonthDay(locale, opts))
-	}
-
 	seq := symbols.NewSeq(locale)
 	seq.Add(opts.Weekday.symbol(), symbols.TxtComma, symbols.TxtSpace)
 	seq.AddSeq(seqMonthDay(locale, opts))


### PR DESCRIPTION
## Summary
- ensure English (Ukraine) places day before month in MMMMEEEEd layout and keeps comma
- handle en-UA day/month order in month-day sequences
- add test for English Ukraine MMMMEEEEd formatting

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895b791a600832f902ebeb7b1ee1098