### PR TITLE
Fix English Ukraine MMMd ordering

### DIFF
--- a/english_ukraine_test.go
+++ b/english_ukraine_test.go
@@ -45,3 +45,16 @@ func TestDateTimeFormat_EnglishUkraineYMd_NoPadding(t *testing.T) {
 		t.Fatalf("want %q got %q", want, got)
 	}
 }
+
+func TestDateTimeFormat_EnglishUkraineMMMd(t *testing.T) {
+        t.Parallel()
+
+        date := time.Date(2025, time.July, 21, 0, 0, 0, 0, time.UTC)
+        locale := language.MustParse("en-UA")
+
+        got := NewDateTimeFormatLayout(locale, "MMMd").Format(date)
+        want := "21 Jul"
+        if got != want {
+                t.Fatalf("want %q got %q", want, got)
+        }
+}

--- a/fmt_md.go
+++ b/fmt_md.go
@@ -41,9 +41,15 @@ func seqMonthDay(locale language.Tag, opts Options) *symbols.Seq {
 				return seq.Add(month, '/', day)
 			}
 
-			if opts.Month.numeric() && opts.Day.numeric() {
-				return seq.Add(symbols.Symbol_d, '/', symbols.Symbol_MM)
-			}
+                       if opts.Month.numeric() && opts.Day.numeric() {
+                               return seq.Add(symbols.Symbol_d, '/', symbols.Symbol_MM)
+                       }
+
+                       return seq.Add(day, symbols.TxtSpace, month)
+               case cldr.RegionUA:
+                       if opts.Month.numeric() && opts.Day.numeric() {
+                               return seq.Add(day, '/', month)
+                       }
 
                        return seq.Add(day, symbols.TxtSpace, month)
                case cldr.RegionCO:


### PR DESCRIPTION
## Summary
- ensure `en-UA` uses day-month order for Month-Day skeleton
- add test for English in Ukraine `MMMd`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895b7c8ca1c832f91b8998eecd8a80b