### PR TITLE
Fix English Ukraine date formatting

### DIFF
--- a/english_ukraine_test.go
+++ b/english_ukraine_test.go
@@ -58,3 +58,29 @@ func TestDateTimeFormat_EnglishUkraineMMMMEEEEd(t *testing.T) {
 		t.Fatalf("want %q got %q", want, got)
 	}
 }
+
+func TestDateTimeFormat_EnglishUkraineMEd(t *testing.T) {
+	t.Parallel()
+
+	date := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	locale := language.MustParse("en-UA")
+
+	got := NewDateTimeFormatLayout(locale, "MEd").Format(date)
+	want := "Wed 1/1"
+	if got != want {
+		t.Fatalf("want %q got %q", want, got)
+	}
+}
+
+func TestDateTimeFormat_EnglishUkraineYM(t *testing.T) {
+	t.Parallel()
+
+	date := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	locale := language.MustParse("en-UA")
+
+	got := NewDateTimeFormatLayout(locale, "yM").Format(date)
+	want := "01/2025"
+	if got != want {
+		t.Fatalf("want %q got %q", want, got)
+	}
+}

--- a/fmt_med.go
+++ b/fmt_med.go
@@ -1,11 +1,20 @@
 package intl
 
 import (
+	"github.com/boltegg/intl/internal/cldr"
 	"github.com/boltegg/intl/internal/symbols"
 	"golang.org/x/text/language"
 )
 
 func seqWeekdayMonthDay(locale language.Tag, opts Options) *symbols.Seq {
+	lang, _, region := locale.Raw()
+
+	if lang == cldr.EN && region == cldr.RegionUA && opts.Month.numeric() && opts.Day.numeric() {
+		return symbols.NewSeq(locale).
+			Add(opts.Weekday.symbol(), symbols.TxtSpace).
+			AddSeq(seqMonthDay(locale, opts))
+	}
+
 	seq := symbols.NewSeq(locale)
 	seq.Add(opts.Weekday.symbol(), symbols.TxtComma, symbols.TxtSpace)
 	seq.AddSeq(seqMonthDay(locale, opts))

--- a/fmt_ym.go
+++ b/fmt_ym.go
@@ -18,6 +18,12 @@ func seqYearMonth(locale language.Tag, opts Options) *symbols.Seq {
 		return seq.Add(symbols.Symbol_MM, '-', year)
 	case cldr.EN:
 		switch region {
+		case cldr.RegionUA:
+			if opts.Month.numeric() || opts.Month.twoDigit() {
+				return seq.Add(symbols.Symbol_MM, '/', year)
+			}
+
+			return seq.Add(month, ' ', year)
 		default:
 			if opts.Month.numeric() || opts.Month.twoDigit() {
 				return seq.Add(month, '/', year)

--- a/fmt_ymde.go
+++ b/fmt_ymde.go
@@ -10,7 +10,7 @@ import (
 func seqWeekdayYearMonthDay(locale language.Tag, opts Options) *symbols.Seq {
 	lang, _, region := locale.Raw()
 
-	if lang == cldr.EN && region == cldr.RegionUA {
+	if lang == cldr.EN && region == cldr.RegionUA && opts.Month.numeric() && opts.Day.numeric() {
 		return symbols.NewSeq(locale).
 			Add(opts.Weekday.symbol(), symbols.TxtSpace).
 			AddSeq(seqYearMonthDay(locale, opts))


### PR DESCRIPTION
## Summary
- ensure MEd skeleton omits comma for English (Ukraine) when using numeric month/day
- pad month value in yM skeleton for English (Ukraine)
- test English (Ukraine) MEd and yM patterns

## Testing
- `go test ./...`
- `go run /tmp/test_en_UA.go`


------
https://chatgpt.com/codex/tasks/task_e_6895bc3df270832fa36c2f95ad416c8f