### PR TITLE
Fix Spanish Colombia MMMd formatting

### DIFF
--- a/fmt_md.go
+++ b/fmt_md.go
@@ -219,6 +219,10 @@ func seqMonthDay(locale language.Tag, opts Options) *symbols.Seq {
 	case cldr.ES:
 		switch region {
 		default:
+			if !opts.Month.numeric() && !opts.Month.twoDigit() {
+				return seq.Add(day, symbols.TxtSpace, symbols.Txt07, symbols.TxtSpace, month)
+			}
+
 			return seq.Add(symbols.Symbol_d, '/', symbols.Symbol_M)
 		case cldr.RegionCL:
 			// month=numeric,day=numeric,out=02-01
@@ -232,12 +236,20 @@ func seqMonthDay(locale language.Tag, opts Options) *symbols.Seq {
 				return seq.Add(symbols.Symbol_dd, '-', symbols.Symbol_MM)
 			}
 
+			if !opts.Month.numeric() && !opts.Month.twoDigit() {
+				return seq.Add(day, symbols.TxtSpace, symbols.Txt07, symbols.TxtSpace, month)
+			}
+
 			return seq.Add(symbols.Symbol_d, '/', symbols.Symbol_M)
 		case cldr.RegionMX, cldr.RegionUS:
 			// month=numeric,day=numeric,out=2/1
 			// month=numeric,day=2-digit,out=02/1
 			// month=2-digit,day=numeric,out=2/01
 			// month=2-digit,day=2-digit,out=02/01
+			if !opts.Month.numeric() && !opts.Month.twoDigit() {
+				return seq.Add(day, symbols.TxtSpace, symbols.Txt07, symbols.TxtSpace, month)
+			}
+
 			return seq.Add(day, '/', month)
 		case cldr.RegionPA, cldr.RegionPR:
 			// month=numeric,day=numeric,out=01/02
@@ -246,6 +258,10 @@ func seqMonthDay(locale language.Tag, opts Options) *symbols.Seq {
 			// month=2-digit,day=2-digit,out=2/1
 			if opts.Month.numeric() {
 				return seq.Add(symbols.Symbol_MM, '/', symbols.Symbol_dd)
+			}
+
+			if !opts.Month.numeric() && !opts.Month.twoDigit() {
+				return seq.Add(day, symbols.TxtSpace, symbols.Txt07, symbols.TxtSpace, month)
 			}
 
 			return seq.Add(symbols.Symbol_d, '/', symbols.Symbol_M)

--- a/spanish_colombia_test.go
+++ b/spanish_colombia_test.go
@@ -1,0 +1,18 @@
+package intl
+
+import (
+	"golang.org/x/text/language"
+	"testing"
+	"time"
+)
+
+func TestDateTimeFormat_SpanishColombia_MMMd(t *testing.T) {
+	t.Parallel()
+	date := time.Date(2024, 9, 2, 0, 0, 0, 0, time.UTC)
+	locale := language.MustParse("es-CO")
+	got := NewDateTimeFormat(locale, Options{Month: MonthShort, Day: DayNumeric}).Format(date)
+	want := "2 de sept."
+	if got != want {
+		t.Fatalf("want %q got %q", want, got)
+	}
+}


### PR DESCRIPTION
## Summary
- ensure Spanish month-day formats insert "de" when month is textual
- add test for es-CO MMMd case

## Testing
- `go test`


------
https://chatgpt.com/codex/tasks/task_e_6895c89961e4832fb3793f5535dd93f4