### PR TITLE
Use 'sep.' for es_CO month abbreviation

### DIFF
--- a/internal/cldr/cldr.go
+++ b/internal/cldr/cldr.go
@@ -64,6 +64,11 @@ func MonthNames(locale string, context, width string) CalendarMonths {
 						names[j] = name + "."
 					}
 				}
+				if context == "format" {
+					if region, _ := tag.Region(); region.String() == "CO" {
+						names[8] = "sep."
+					}
+				}
 			}
 			return names
 		}

--- a/spanish_colombia_test.go
+++ b/spanish_colombia_test.go
@@ -11,7 +11,7 @@ func TestDateTimeFormat_SpanishColombia_MMMd(t *testing.T) {
 	date := time.Date(2024, 9, 2, 0, 0, 0, 0, time.UTC)
 	locale := language.MustParse("es-CO")
 	got := NewDateTimeFormat(locale, Options{Month: MonthShort, Day: DayNumeric}).Format(date)
-	want := "2 de sept."
+	want := "2 de sep."
 	if got != want {
 		t.Fatalf("want %q got %q", want, got)
 	}


### PR DESCRIPTION
## Summary
- fix es_CO September short month to `sep.` when formatting dates
- keep stand-alone month unchanged
- update Spanish (Colombia) month test

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895cc96cf58832f8c9bcdf74efaffec