### PR TITLE
Add Spanish day period names

### DIFF
--- a/internal/cldr/dayperiod.go
+++ b/internal/cldr/dayperiod.go
@@ -9,6 +9,8 @@ func DayPeriods(locale language.Tag) [2]string {
 	switch base.String() {
 	case "en":
 		return [2]string{"AM", "PM"}
+	case "es":
+		return [2]string{"a.\u00a0m.", "p.\u00a0m."}
 	default:
 		return [2]string{"AM", "PM"}
 	}

--- a/spanish_colombia_test.go
+++ b/spanish_colombia_test.go
@@ -16,3 +16,16 @@ func TestDateTimeFormat_SpanishColombia_MMMd(t *testing.T) {
 		t.Fatalf("want %q got %q", want, got)
 	}
 }
+
+func TestDateTimeFormat_SpanishColombia_jm(t *testing.T) {
+	t.Parallel()
+
+	date := time.Date(2025, 1, 1, 4, 0, 0, 0, time.UTC)
+	locale := language.MustParse("es-CO")
+
+	got := NewDateTimeFormatLayout(locale, "jm").Format(date)
+	want := "4:00 a.\u00a0m."
+	if got != want {
+		t.Fatalf("want %q got %q", want, got)
+	}
+}


### PR DESCRIPTION
## Summary
- localize AM/PM for Spanish locales using CLDR strings
- test Spanish (Colombia) jm format to verify localized day periods

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895d74c4708832fa5e1d662f2e4705f