### PR TITLE
Fix Colombian Spanish month formatting

### DIFF
--- a/fmt_ym.go
+++ b/fmt_ym.go
@@ -164,7 +164,11 @@ func seqYearMonth(locale language.Tag, opts Options) *symbols.Seq {
 	case cldr.ES:
 		switch region {
 		default:
-			return seq.Add(symbols.Symbol_M, '/', year)
+			if opts.Month.numeric() || opts.Month.twoDigit() {
+				return seq.Add(month, '/', year)
+			}
+
+			return seq.Add(month, ' ', symbols.Txt07, ' ', year)
 		case cldr.RegionAR:
 			// year=numeric,month=numeric,out=1-2024
 			// year=numeric,month=2-digit,out=1/2024

--- a/layout.go
+++ b/layout.go
@@ -125,6 +125,10 @@ func ParseLayout(layout string) (Options, error) {
 		i = j
 	}
 
+	if !opts.Month.und() && opts.Day.und() && opts.Year.und() && opts.Weekday.und() && opts.Hour.und() && opts.Minute.und() && opts.Second.und() && opts.Era.und() && opts.Quarter.und() {
+		opts.MonthStandalone = true
+	}
+
 	return opts, nil
 }
 

--- a/spanish_colombia_test.go
+++ b/spanish_colombia_test.go
@@ -29,3 +29,29 @@ func TestDateTimeFormat_SpanishColombia_jm(t *testing.T) {
 		t.Fatalf("want %q got %q", want, got)
 	}
 }
+
+func TestDateTimeFormat_SpanishColombia_MMM(t *testing.T) {
+	t.Parallel()
+
+	date := time.Date(2025, 9, 1, 0, 0, 0, 0, time.UTC)
+	locale := language.MustParse("es-CO")
+
+	got := NewDateTimeFormatLayout(locale, "MMM").Format(date)
+	want := "sept."
+	if got != want {
+		t.Fatalf("want %q got %q", want, got)
+	}
+}
+
+func TestDateTimeFormat_SpanishColombia_yMMM(t *testing.T) {
+	t.Parallel()
+
+	date := time.Date(2025, 4, 1, 0, 0, 0, 0, time.UTC)
+	locale := language.MustParse("es-CO")
+
+	got := NewDateTimeFormatLayout(locale, "yMMM").Format(date)
+	want := "abr. de 2025"
+	if got != want {
+		t.Fatalf("want %q got %q", want, got)
+	}
+}


### PR DESCRIPTION
## Summary
- treat standalone month layouts as standalone to get correct "sept." abbreviation
- format Spanish year-month with "<month> de <year>" when using month names
- add tests for Colombian Spanish `MMM` and `yMMM`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895d9862ea4832faea54793fa9f62a0