### PR TITLE
Format english_colombia_test.go using gofmt

### DIFF
--- a/english_colombia_test.go
+++ b/english_colombia_test.go
@@ -52,11 +52,11 @@ func TestDateTimeFormat_EnglishColombiaMMMMd(t *testing.T) {
 	date := time.Date(2025, 11, 1, 0, 0, 0, 0, time.UTC)
 	locale := language.MustParse("en-CO")
 
-        got := NewDateTimeFormatLayout(locale, "MMMMd").Format(date)
-        want := "November 1"
-        if got != want {
-                t.Fatalf("want %q got %q", want, got)
-        }
+	got := NewDateTimeFormatLayout(locale, "MMMMd").Format(date)
+	want := "November 1"
+	if got != want {
+		t.Fatalf("want %q got %q", want, got)
+	}
 }
 
 func TestDateTimeFormat_EnglishColombiaMMMMEEEEd(t *testing.T) {


### PR DESCRIPTION
## Summary
- format `english_colombia_test.go` with gofmt to ensure canonical tab indentation

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895dfd007b4832fa5c10ad5de3fa34b