### PR TITLE
Refactor layout parsing API

### DIFF
--- a/english_colombia_test.go
+++ b/english_colombia_test.go
@@ -13,7 +13,11 @@ func TestDateTimeFormat_EnglishColombiaYMd(t *testing.T) {
 	date := time.Date(2025, 11, 17, 0, 0, 0, 0, time.UTC)
 	locale := language.MustParse("en-CO")
 
-	got := NewDateTimeFormatLayout(locale, "yMd").Format(date)
+	fmt, err := NewDateTimeFormatLayout(locale, "yMd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := fmt.Format(date)
 	want := "17/11/2025"
 	if got != want {
 		t.Fatalf("want %q got %q", want, got)
@@ -26,7 +30,11 @@ func TestDateTimeFormat_EnglishColombiaYMdSeptember(t *testing.T) {
 	date := time.Date(2025, 9, 5, 0, 0, 0, 0, time.UTC)
 	locale := language.MustParse("en-CO")
 
-	got := NewDateTimeFormatLayout(locale, "yMd").Format(date)
+	fmt, err := NewDateTimeFormatLayout(locale, "yMd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := fmt.Format(date)
 	want := "5/09/2025"
 	if got != want {
 		t.Fatalf("want %q got %q", want, got)
@@ -39,7 +47,11 @@ func TestDateTimeFormat_EnglishColombiaMEd(t *testing.T) {
 	date := time.Date(2025, 2, 4, 0, 0, 0, 0, time.UTC)
 	locale := language.MustParse("en-CO")
 
-	got := NewDateTimeFormatLayout(locale, "MEd").Format(date)
+	fmt, err := NewDateTimeFormatLayout(locale, "MEd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := fmt.Format(date)
 	want := "Tue, 4/02"
 	if got != want {
 		t.Fatalf("want %q got %q", want, got)
@@ -52,7 +64,11 @@ func TestDateTimeFormat_EnglishColombiaMMMMd(t *testing.T) {
 	date := time.Date(2025, 11, 1, 0, 0, 0, 0, time.UTC)
 	locale := language.MustParse("en-CO")
 
-	got := NewDateTimeFormatLayout(locale, "MMMMd").Format(date)
+	fmt, err := NewDateTimeFormatLayout(locale, "MMMMd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := fmt.Format(date)
 	want := "November 1"
 	if got != want {
 		t.Fatalf("want %q got %q", want, got)
@@ -65,7 +81,11 @@ func TestDateTimeFormat_EnglishColombiaMMMMEEEEd(t *testing.T) {
 	date := time.Date(2025, 4, 3, 0, 0, 0, 0, time.UTC)
 	locale := language.MustParse("en-CO")
 
-	got := NewDateTimeFormatLayout(locale, "MMMMEEEEd").Format(date)
+	fmt, err := NewDateTimeFormatLayout(locale, "MMMMEEEEd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := fmt.Format(date)
 	want := "Thursday, 3 April"
 	if got != want {
 		t.Fatalf("want %q got %q", want, got)

--- a/english_ukraine_test.go
+++ b/english_ukraine_test.go
@@ -13,7 +13,11 @@ func TestDateTimeFormat_EnglishUkraineYMd(t *testing.T) {
 	date := time.Date(2025, 12, 31, 0, 0, 0, 0, time.UTC)
 	locale := language.MustParse("en-UA")
 
-	got := NewDateTimeFormatLayout(locale, "yMd").Format(date)
+	fmt, err := NewDateTimeFormatLayout(locale, "yMd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := fmt.Format(date)
 	want := "31/12/2025"
 	if got != want {
 		t.Fatalf("want %q got %q", want, got)
@@ -26,7 +30,11 @@ func TestDateTimeFormat_EnglishUkraineYMed(t *testing.T) {
 	date := time.Date(2025, 4, 1, 0, 0, 0, 0, time.UTC)
 	locale := language.MustParse("en-UA")
 
-	got := NewDateTimeFormatLayout(locale, "yMEd").Format(date)
+	fmt, err := NewDateTimeFormatLayout(locale, "yMEd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := fmt.Format(date)
 	want := "Tue 1/4/2025"
 	if got != want {
 		t.Fatalf("want %q got %q", want, got)
@@ -39,7 +47,11 @@ func TestDateTimeFormat_EnglishUkraineYMd_NoPadding(t *testing.T) {
 	date := time.Date(2025, time.October, 6, 0, 0, 0, 0, time.UTC)
 	locale := language.MustParse("en-UA")
 
-	got := NewDateTimeFormatLayout(locale, "yMd").Format(date)
+	fmt, err := NewDateTimeFormatLayout(locale, "yMd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := fmt.Format(date)
 	want := "6/10/2025"
 	if got != want {
 		t.Fatalf("want %q got %q", want, got)
@@ -52,7 +64,11 @@ func TestDateTimeFormat_EnglishUkraineMMMMEEEEd(t *testing.T) {
 	date := time.Date(2014, time.November, 30, 0, 0, 0, 0, time.UTC)
 	locale := language.MustParse("en-UA")
 
-	got := NewDateTimeFormatLayout(locale, "MMMMEEEEd").Format(date)
+	fmt, err := NewDateTimeFormatLayout(locale, "MMMMEEEEd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := fmt.Format(date)
 	want := "Sunday, 30 November"
 	if got != want {
 		t.Fatalf("want %q got %q", want, got)
@@ -65,7 +81,11 @@ func TestDateTimeFormat_EnglishUkraineMEd(t *testing.T) {
 	date := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 	locale := language.MustParse("en-UA")
 
-	got := NewDateTimeFormatLayout(locale, "MEd").Format(date)
+	fmt, err := NewDateTimeFormatLayout(locale, "MEd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := fmt.Format(date)
 	want := "Wed 1/1"
 	if got != want {
 		t.Fatalf("want %q got %q", want, got)
@@ -78,7 +98,11 @@ func TestDateTimeFormat_EnglishUkraineYM(t *testing.T) {
 	date := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 	locale := language.MustParse("en-UA")
 
-	got := NewDateTimeFormatLayout(locale, "yM").Format(date)
+	fmt, err := NewDateTimeFormatLayout(locale, "yM")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := fmt.Format(date)
 	want := "01/2025"
 	if got != want {
 		t.Fatalf("want %q got %q", want, got)

--- a/internal/test/main.go
+++ b/internal/test/main.go
@@ -13,6 +13,10 @@ func main() {
 	v := intl.NewDateTimeFormat(language.English, intl.Options{Minute: intl.Minute2Digit, Hour: intl.Hour2Digit})
 	fmt.Println(v.Format(time.Now()))
 
-	v = intl.NewDateTimeFormatLayout(language.English, "MEd")
+	var err error
+	v, err = intl.NewDateTimeFormatLayout(language.English, "MEd")
+	if err != nil {
+		panic(err)
+	}
 	fmt.Println(v.Format(time.Now()))
 }

--- a/layout.go
+++ b/layout.go
@@ -132,18 +132,13 @@ func ParseLayout(layout string) (Options, error) {
 	return opts, nil
 }
 
-// MustParseLayout is like [ParseLayout] but panics on error.
-func MustParseLayout(layout string) Options {
+// NewDateTimeFormatLayout creates [DateTimeFormat] using a CLDR skeleton
+// layout string. It returns an error if the layout contains unsupported symbols.
+func NewDateTimeFormatLayout(locale language.Tag, layout string) (DateTimeFormat, error) {
 	opts, err := ParseLayout(layout)
 	if err != nil {
-		panic(err)
+		return DateTimeFormat{}, err
 	}
 
-	return opts
-}
-
-// NewDateTimeFormatLayout creates [DateTimeFormat] using a CLDR skeleton
-// layout string. It panics if the layout contains unsupported symbols.
-func NewDateTimeFormatLayout(locale language.Tag, layout string) DateTimeFormat {
-	return NewDateTimeFormat(locale, MustParseLayout(layout))
+	return NewDateTimeFormat(locale, opts), nil
 }

--- a/layout_test.go
+++ b/layout_test.go
@@ -11,8 +11,11 @@ func TestDateTimeFormat_Layout_Hms(t *testing.T) {
 	t.Parallel()
 
 	date := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
-	got := NewDateTimeFormatLayout(language.Persian, "Hms").Format(date)
-
+	fmt, err := NewDateTimeFormatLayout(language.Persian, "Hms")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := fmt.Format(date)
 	if got != "۰۳:۰۴:۰۵" {
 		t.Fatalf("want %q got %q", "۰۳:۰۴:۰۵", got)
 	}
@@ -59,7 +62,11 @@ func TestDateTimeFormat_Layout_Patterns(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.layout, func(t *testing.T) {
-			got := NewDateTimeFormatLayout(language.English, tt.layout).Format(date)
+			fmt, err := NewDateTimeFormatLayout(language.English, tt.layout)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := fmt.Format(date)
 			if got != tt.want {
 				t.Fatalf("want %q got %q", tt.want, got)
 			}

--- a/russian_ua_test.go
+++ b/russian_ua_test.go
@@ -26,7 +26,11 @@ func TestDateTimeFormat_RussianUkraineWeekday(t *testing.T) {
 	date := time.Date(2024, 3, 27, 0, 0, 0, 0, time.UTC)
 	locale := language.MustParse("ru-UA")
 
-	got := NewDateTimeFormatLayout(locale, "E").Format(date)
+	fmt, err := NewDateTimeFormatLayout(locale, "E")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := fmt.Format(date)
 	want := "Ср"
 	if got != want {
 		t.Fatalf("want %q got %q", want, got)
@@ -39,7 +43,11 @@ func TestDateTimeFormat_RussianUkraineYMed(t *testing.T) {
 	date := time.Date(2025, 5, 5, 0, 0, 0, 0, time.UTC)
 	locale := language.MustParse("ru-UA")
 
-	got := NewDateTimeFormatLayout(locale, "yMEd").Format(date)
+	fmt, err := NewDateTimeFormatLayout(locale, "yMEd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := fmt.Format(date)
 	want := "Пн, 5.05.2025"
 	if got != want {
 		t.Fatalf("want %q got %q", want, got)
@@ -52,7 +60,11 @@ func TestDateTimeFormat_RussianUkraineYMd(t *testing.T) {
 	date := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 	locale := language.MustParse("ru-UA")
 
-	got := NewDateTimeFormatLayout(locale, "yMd").Format(date)
+	fmt, err := NewDateTimeFormatLayout(locale, "yMd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := fmt.Format(date)
 	want := "01.01.2025"
 	if got != want {
 		t.Fatalf("want %q got %q", want, got)

--- a/spanish_colombia_test.go
+++ b/spanish_colombia_test.go
@@ -23,7 +23,11 @@ func TestDateTimeFormat_SpanishColombia_jm(t *testing.T) {
 	date := time.Date(2025, 1, 1, 4, 0, 0, 0, time.UTC)
 	locale := language.MustParse("es-CO")
 
-	got := NewDateTimeFormatLayout(locale, "jm").Format(date)
+	fmt, err := NewDateTimeFormatLayout(locale, "jm")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := fmt.Format(date)
 	want := "4:00 a.m."
 	if got != want {
 		t.Fatalf("want %q got %q", want, got)
@@ -36,7 +40,11 @@ func TestDateTimeFormat_SpanishColombia_MMM(t *testing.T) {
 	date := time.Date(2025, 9, 1, 0, 0, 0, 0, time.UTC)
 	locale := language.MustParse("es-CO")
 
-	got := NewDateTimeFormatLayout(locale, "MMM").Format(date)
+	fmt, err := NewDateTimeFormatLayout(locale, "MMM")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := fmt.Format(date)
 	want := "sept."
 	if got != want {
 		t.Fatalf("want %q got %q", want, got)
@@ -49,7 +57,11 @@ func TestDateTimeFormat_SpanishColombia_yMMM(t *testing.T) {
 	date := time.Date(2025, 4, 1, 0, 0, 0, 0, time.UTC)
 	locale := language.MustParse("es-CO")
 
-	got := NewDateTimeFormatLayout(locale, "yMMM").Format(date)
+	fmt, err := NewDateTimeFormatLayout(locale, "yMMM")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := fmt.Format(date)
 	want := "abr. de 2025"
 	if got != want {
 		t.Fatalf("want %q got %q", want, got)

--- a/ukrainian_ua_test.go
+++ b/ukrainian_ua_test.go
@@ -29,7 +29,11 @@ func TestDateTimeFormat_UkrainianUkraine(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := NewDateTimeFormatLayout(locale, tt.layout).Format(tt.date)
+			fmt, err := NewDateTimeFormatLayout(locale, tt.layout)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := fmt.Format(tt.date)
 			if got != tt.want {
 				t.Fatalf("want %q got %q", tt.want, got)
 			}


### PR DESCRIPTION
## Summary
- remove MustParseLayout helper
- make NewDateTimeFormatLayout return an error
- update tests for new API

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68961c6d3f74832f9c6144992b1af3b9